### PR TITLE
Add modular cfw sourcing for ports: F-Zero Pocket & Freedom Planet

### DIFF
--- a/ports/f-zeropocket/F-Zero Pocket.sh
+++ b/ports/f-zeropocket/F-Zero Pocket.sh
@@ -8,18 +8,11 @@ else
 fi
 
 source $controlfolder/control.txt
-
+source $controlfolder/device_info.txt
 get_controls
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 $ESUDO chmod 666 /dev/tty0
-
-# We check on emuelec based CFWs the OS_NAME 
-[ -f "/etc/os-release" ] && source "/etc/os-release"
-
-if [ "$OS_NAME" == "JELOS" ]; then
-  export SPA_PLUGIN_DIR="/usr/lib32/spa-0.2"
-  export PIPEWIRE_MODULE_DIR="/usr/lib32/pipewire-0.3/"
-fi
 
 GAMEDIR="/$directory/ports/f-zeropocket"
 

--- a/ports/freedom.planet/Freedom Planet.sh
+++ b/ports/freedom.planet/Freedom Planet.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-
-
 if [ -d "/opt/system/Tools/PortMaster/" ]; then
   controlfolder="/opt/system/Tools/PortMaster"
 elif [ -d "/opt/tools/PortMaster/" ]; then
@@ -10,8 +8,9 @@ else
 fi
 
 source $controlfolder/control.txt
-
+source $controlfolder/device_info.txt
 get_controls
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 $ESUDO chmod 666 /dev/tty1
 


### PR DESCRIPTION
Use the new modular cfw sourcing for two ports: Freedom Planet & F-Zero Pocket.

Note: Freedom Planet needs [a pull for the GUI](https://github.com/PortsMaster/PortMaster-GUI/pull/57).