### PR TITLE
Remove incorrect note for DevilutionX

### DIFF
--- a/ports/devilutionx/README.md
+++ b/ports/devilutionx/README.md
@@ -4,8 +4,6 @@ Copy diabdat.mpq from your CD or GoG installation (or extract it from the GoG in
 
 Do not delete the gamecontrollerdb.txt file in the /roms/ports/devilution folder or there will be no controller support in the game! For controls, see here
 
-**Important Note: ** It’s been reported that you must make sure you use the GOG version of diabdat.mpq with the newest patch_rt.mpq or you may experience a freeze of the game around level 20.
-
 If you experience issues after a version upgrade, backup your save file and uninstall/reinstall the port.
 
 If you make a config change that crashes the game, you can delete the ini file to get the game back to a good state


### PR DESCRIPTION
This information is not correct. The GOG data file is identical to the CD release, all releases will work just fine (1.00 CD, 1.04 CD, 1.08 CD, Mac CD, GOG release, BattleNet release). patch_rt.mpq isn't even loaded so having it makes no difference.

Also there are only 16 levels in Diablo, so how would you get stuck on level 20...

Source: I'm an upstream maintainer.