### PR TITLE
Update Bittrip runner 2 README.md - (recent) crash if empty dlc1 folder exists

### DIFF
--- a/ports/bittriprunner2/README.md
+++ b/ports/bittriprunner2/README.md
@@ -1,6 +1,7 @@
 ## Notes
 
 You'll need to source your own Linux version of BitTrip Runner2 game, and copy your Linux Game files (runner2, Runner2.png, package.toc and the other 9 folders) to the bittriprunner2 folder. 
+Do not copy the dlc1 one folder if it is empty or the game might crash.
 
 Beware of a certain thing with the intro, where an unskippable black screen will appear for a few seconds, followed by the narator talking, after which a normal skippable intro proceeds.
 


### PR DESCRIPTION
Bit trip runner 2 was working fine on my rg35xx plus for me a week ago but reinstalling it and reuploading the game files made it crash with an error mentioning that the dlc1 one folder could not be loaded. I noticed in my case that the dlc1 folder was empty so i removed it and the game booted fine.

I don't know what would happen when people do own the dlc, i'm guessing the dlc1 folder will no longer be empty and game will be able to boot / load it as well but since i don't own the dlc i can not test this.

![image](https://github.com/PortsMaster/PortMaster-New/assets/10714776/47802260-4ea1-4712-ab15-47eff79e01b4)

So i updated the readme to mention to not copy the dlc1 folder if it is empty or that the game might crash then, this did not used to happen before so maybe the rlvm recompile for armhf might got something todo with this and i'm not sure if that needs to be looked at / investigated, but at least for now mentioning the empty dlc1 one folder might be fine.

I also don't know if any other games use rlvm and if they exhibit the same problem

edit: fwiw i bought the dlc was only 0.99€ and the game does not crash if you upload the dlc1 folder now (containing extra assets) but the characters don't load either (not a big issue) 