### PR TITLE
Update Stardew Valley instructions

### DIFF
--- a/ports/stardewvalley/port.json
+++ b/ports/stardewvalley/port.json
@@ -9,7 +9,7 @@
     "attr": {
         "title": "Stardew Valley",
         "desc": "An open-ended country-life RPG!",
-        "inst": "You must have a copy of the compatibility version of Stardew Valley copied to the ports/stardewvalley/gamedata folder.",
+        "inst": "You must have a copy of the 1.5.6 compatibility version of Stardew Valley copied to the ports/stardewvalley/gamedata folder. In Steam console use `download_depot 413150 413153 8322187383152776702`.",
         "genres": [
             "simulation",
             "rpg"


### PR DESCRIPTION
Stardew Valley compatibility branch was updated to v1.6 today. This uses .NET 6 which is currently broken in the port. Update the port.json instructions to use 1.5.6 until this is fixed (if ever).