### PR TITLE
Update cannonball-lr port.json

### DIFF
--- a/ports/cannonball-lr/port.json
+++ b/ports/cannonball-lr/port.json
@@ -20,6 +20,8 @@
         "rtr": false,
         "runtime": null,
         "reqs": [],
-        "arch": []
+        "arch": [
+            "aarch64"
+        ]
     }
 }


### PR DESCRIPTION
It looks as though if no arch set in port.json then it shows up for x86_64 and I am guessing other arch like armhf?

Test to see if this fixes.

If it does I will change the rest that are missing 

See screenshot here for list of affected ports

https://discord.com/channels/1122861252088172575/1223212073358594058/1223579038996500530