### PR TITLE
Balatro - Allowing save to the same path as the game

### DIFF
--- a/ports/balatro/Balatro.sh
+++ b/ports/balatro/Balatro.sh
@@ -19,10 +19,12 @@ get_controls
 
 GAMEDIR="/$directory/ports/balatro"
 
+export XDG_DATA_HOME="$GAMEDIR/saves" # allowing saving to the same path as the game
 export XDG_CONFIG_HOME="$GAMEDIR/saves"
 export LD_LIBRARY_PATH="$GAMEDIR/libs:$LD_LIBRARY_PATH"
 
-mkdir "$XDG_DATA_HOME"
+mkdir -p "$XDG_DATA_HOME"
+mkdir -p "$XDG_CONFIG_HOME"
 
 ## Uncomment the following file to log the output, for debugging purpose
 # exec > >(tee "$GAMEDIR/log.txt") 2>&1


### PR DESCRIPTION
Balatro - updating the save path to be the game folder.

With the update to the header, the XDG_DATA_HOME unfortunately does not point to the save folder anymore causing the file to be saved on .local/share.

This is the update that allows save to stay in the save folder of the ports