### PR TITLE
Fix Stardew Valley port when using GOG Compatibility build data.

### DIFF
--- a/ports/stardewvalley/StardewValley.sh
+++ b/ports/stardewvalley/StardewValley.sh
@@ -62,7 +62,10 @@ fi
 cd "$gamedir/gamedata"
 
 # Fix for the Linux builds, use mono-provided libraries instead.
-rm -f MonoGame.Framework.* System.dll
+# Exception for the System.Data.* assemblies, since Stardew needs
+# xxHash types we would otherwise not provide.
+mv System.Data*.dll "$gamedir/dlls"
+rm -f MonoGame.Framework.* System*.dll
 
 # Check if it's the Windows or Linux version
 if [[ -f "Stardew Valley.exe" ]]; then


### PR DESCRIPTION
There's a difference in bundled assemblies that was not noticed and caused a crash on boot. This fixes the problem by taking the xxHash assemblies from the game and then deletes the incompatible System ones.