### PR TITLE
Yellow Jacket - Remove japanese characters on port.json

### DIFF
--- a/ports/yellowjacket/port.json
+++ b/ports/yellowjacket/port.json
@@ -7,11 +7,11 @@
     ],
     "items_opt": null,
     "attr": {
-        "title": "Y E L L O W - J A C K E T | イエロージャケット",
+        "title": "Y E L L O W - J A C K E T",
         "porter": [
             "Wark91"
         ],
-        "desc": "Y E L L O W - J A C K E T | イエロージャケット (or just yellow jacket) is a vaporwave arcade shoot-em-up about a motorcyclist running from the government in this classic 80s style arcade shmup! Can you get the highest score?",
+        "desc": "Y E L L O W - J A C K E T (or just yellow jacket) is a vaporwave arcade shoot-em-up about a motorcyclist running from the government in this classic 80s style arcade shmup! Can you get the highest score?",
         "inst": "Download the game on itch.io page and retrieve the file data.win from the Y E L L O W - J A C K E T.zip. After, data.win needs to be place on to the folder ports/yellowjacket/gamedata.",
         "genres": [
             "arcade",


### PR DESCRIPTION
As discussed on discord, the portmaster-gui doesn't support japanese characters.
This commit remove them on port.json file.

Thanks