### PR TITLE
Fix cannonballst for trimui

### DIFF
--- a/ports/cannonball-st/Cannonball-st.sh
+++ b/ports/cannonball-st/Cannonball-st.sh
@@ -33,7 +33,7 @@ echo "Loading, please wait... " > /dev/tty0
 
 $ESUDO chmod +x "$GAMEDIR/cannonball"
 
-./cannonball |& tee log.txt /dev/tty0
+./cannonball 2>&1 | tee log.txt /dev/tty0
 
 $ESUDO kill -9 "$(pidof gptokeyb)"
 $ESUDO systemctl restart oga_events &

--- a/ports/cannonball-st/Cannonball-st.sh
+++ b/ports/cannonball-st/Cannonball-st.sh
@@ -16,24 +16,16 @@ source $controlfolder/control.txt
 
 get_controls
 
-$ESUDO chmod 666 /dev/tty0
-$ESUDO chmod 666 /dev/tty1
-printf "\033c" > /dev/tty0
-printf "\033c" > /dev/tty1
+exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
 GAMEDIR="/$directory/ports/Cannonball-st"
 
 export LD_LIBRARY_PATH="/$directory/ports/Cannonball-st/lib"
- 
+
 cd "$GAMEDIR"
 
-$ESUDO chmod 666 /dev/uinput
 $GPTOKEYB "cannonball" &
-echo "Loading, please wait... " > /dev/tty0
-
-$ESUDO chmod +x "$GAMEDIR/cannonball"
-
-./cannonball 2>&1 | tee log.txt /dev/tty0
+./cannonball
 
 $ESUDO kill -9 "$(pidof gptokeyb)"
 $ESUDO systemctl restart oga_events &


### PR DESCRIPTION
Trimui doesn't support shorthand  '|&' operator for redirecting stdout and stderr; so fails to start because of that. Changed to using explicitly 2>&1. 