### PR TITLE
Fix noparachute genre casing

### DIFF
--- a/ports/noparachute/gameinfo.xml
+++ b/ports/noparachute/gameinfo.xml
@@ -8,6 +8,6 @@
     <releasedate>20210405T000000</releasedate>
     <developer>Wherry</developer>
     <publisher>Wherry</publisher>
-    <genre>Action</genre>
+    <genre>action</genre>
   </game>
 </gameList>

--- a/ports/noparachute/port.json
+++ b/ports/noparachute/port.json
@@ -12,7 +12,7 @@
             "Troidem"
         ],
         "desc": "No Parachute is a fast-paced arcade game with a pixel art style, in which you will dodge various obstacles in free fall. The man jumped out of a plane, and his parachute didn’t open. But instead of crashing, he fell into a mysterious hole in the ground. He’ll have to fly through a lot of mines and tunnels and meet unexpected visitors. As the game progresses, the unsuccessful skydiver will have to use all his skill and reaction to survive. You will have very little time to assess the situation and make the right decisions, so be prepared to engage your entire concentration. Try to catch Zen (without burning your ass)!",
-        "inst": "Purchase and download the game https://store.steampowered.com/app/1575300/No_Parachute/ and copy the exe file into the port folder."
+        "inst": "Purchase and download the game https://store.steampowered.com/app/1575300/No_Parachute/ and copy the exe file into the port folder.",
         "genres": [
             "action"
         ],

--- a/ports/noparachute/port.json
+++ b/ports/noparachute/port.json
@@ -14,7 +14,7 @@
         "desc": "No Parachute is a fast-paced arcade game with a pixel art style, in which you will dodge various obstacles in free fall. The man jumped out of a plane, and his parachute didn’t open. But instead of crashing, he fell into a mysterious hole in the ground. He’ll have to fly through a lot of mines and tunnels and meet unexpected visitors. As the game progresses, the unsuccessful skydiver will have to use all his skill and reaction to survive. You will have very little time to assess the situation and make the right decisions, so be prepared to engage your entire concentration. Try to catch Zen (without burning your ass)!",
         "inst": "Purchase and download the game https://store.steampowered.com/app/1575300/No_Parachute/ and copy the exe file into the port folder."
         "genres": [
-            "Action"
+            "action"
         ],
         "image": {},
         "rtr": false,


### PR DESCRIPTION
The game still doesn't show on the site, so I rechecked to ensure everything is correct. I noticed that only the genre name has different casing compared to other ports and the site generator. I don't know if it really makes a difference, but I fixed it just to be sure.