### PR TITLE
Fix for 2048.sh not launching in aarch64 muOS build

### DIFF
--- a/ports/2048/2048.sh
+++ b/ports/2048/2048.sh
@@ -26,9 +26,12 @@ elif [[ $CFW_NAME == "RetroOZ" ]]; then
 elif [[ $CFW_NAME == "ArkOS" ]]; then
   raloc="/usr/local/bin"
   raconf=""
-elif [[ $CFW_NAME == "muOS" ]]; then
+elif [[ $CFW_NAME == "muOS" && $DEVICE_ARCH == "aarch64" ]]; then
+  raloc="/usr/bin"
+  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch32.cfg"
+elif [[ $CFW_NAME == "muOS" && $DEVICE_ARCH != "aarch64" ]]; then
   raloc="/mnt/mmc/MUOS"
-  raconf="--config /mnt/mmc/MUOS/.retroarch/retroarch.cfg"
+  raconf="/mnt/mmc/MUOS/.retroarch/retroarch.cfg"
 else
   raloc="/usr/bin"
   raconf=""
@@ -36,5 +39,10 @@ fi
 
 GAMEDIR="/$directory/ports/2048"
 
-$GPTOKEYB "retroarch" &
-$raloc/retroarch $raconf -L $GAMEDIR/2048_libretro.so.${DEVICE_ARCH}
+if [[ $CFW_NAME == "muOS" && $DEVICE_ARCH == "aarch64" ]]; then
+  $GPTOKEYB "retroarch32" &
+  $raloc/retroarch32 $raconf -L $GAMEDIR/2048_libretro.so.armhf
+else
+  $GPTOKEYB "retroarch" &
+  $raloc/retroarch $raconf -L $GAMEDIR/2048_libretro.so.${DEVICE_ARCH}
+fi

--- a/ports/2048/2048.sh
+++ b/ports/2048/2048.sh
@@ -31,7 +31,7 @@ elif [[ $CFW_NAME == "muOS" && $DEVICE_ARCH == "aarch64" ]]; then
   raconf="--config /mnt/mmc/MUOS/retroarch/retroarch32.cfg"
 elif [[ $CFW_NAME == "muOS" && $DEVICE_ARCH != "aarch64" ]]; then
   raloc="/mnt/mmc/MUOS"
-  raconf="/mnt/mmc/MUOS/.retroarch/retroarch.cfg"
+  raconf="--config /mnt/mmc/MUOS/.retroarch/retroarch.cfg"
 else
   raloc="/usr/bin"
   raconf=""


### PR DESCRIPTION
# Modification for 2048
Added conditional statements to check for muOS aarch64 and use the armhf binary instead of aarch64.