### PR TITLE
Fix incorrect ScreenWidth for 4:3 devices

### DIFF
--- a/ports/sonic.cd/soniccd/settings.ini
+++ b/ports/sonic.cd/soniccd/settings.ini
@@ -37,7 +37,7 @@ EnhancedScaling=true
 ; How big the window will be
 WindowScale=2
 ; How wide the base screen will be in pixels
-ScreenWidth=360
+ScreenWidth=320
 ; Determines the target FPS
 RefreshRate=60
 


### PR DESCRIPTION
360px is too wide, causes artifacts on the right side. 320px is perfect.
