### PR TITLE
Increase window resolution and fullscreen by default

### DIFF
--- a/ports/sonic.mania/sonicmania/Settings.ini
+++ b/ports/sonic.mania/sonicmania/Settings.ini
@@ -13,14 +13,14 @@ devMenu=y
 [Video]
 ; NB: Fullscreen Resolution can be explicitly set with values fsWidth and fsHeight
 ; If not listed, fullscreen will just use the desktop resolution
-windowed=y
+windowed=n
 border=n
 exclusiveFS=y
 vsync=y
 tripleBuffering=n
 pixWidth=320
-winWidth=320
-winHeight=240
+winWidth=640
+winHeight=480
 refreshRate=60
 shaderSupport=y
 screenShader=0


### PR DESCRIPTION
This change prevents the game from appearing too small and not filling the screen on 4:3 640x480 devices (i.e. RG35XX Plus/H/2024). Changing these settings in-game wipes the .ini file.

# New Port for { Game Title }

## Game Information
- **Title**: { Game Title }
- **URL**: { Link to project page or source control page }

## Submission Requirements

### CFW Tests
Ensure your game has been tested on all major CFWs:
- [ ] AmberELEC
- [ ] ArkOS
- [ ] ROCKNIX
- [ ] muOS

### Resolution Tests
Test all major resolutions:
- [ ] 480x320
- [ ] 640x480
- [ ] 720x720 (RGB30)
- [ ] Higher resolutions (e.g., 1280x720)

## File Structure
- Your port should have the following structure:
  - portname/
    - port.json
    - README.md
    - screenshot.jpg
    - cover.jpg
    - gameinfo.xml
    - Port Name.sh
    - portname/
      - <portfiles here>

## Additional Resources
For an in-depth guide on creating a pull request, refer to: [PortMaster Game Packaging Guide](https://portmaster.games/packaging.html#creating-a-pull-request)
