### PR TITLE
Rewrote instructions to streamline it with simplified method.

### DIFF
--- a/ports/undertale/port.json
+++ b/ports/undertale/port.json
@@ -9,7 +9,7 @@
     "attr": {
         "title": "Undertale",
         "desc": "Undertale loader.",
-        "inst": "You must have a copy of Undertale Linux version assets copied to the ports/undertale/assets folder.  For more info on the setup needs, see https://github.com/christianhaitian/arkos/wiki/ArkOS-Emulators-and-Ports-information",
+        "inst": "If you have a copy of the Undertale Linux version, copy its `game.unx`, `credits.txt`, `splash.png` and various `.ogg` files to the `ports/undertale/assets` folder.\n\nIf you don't have the Linux version, simply rename Undertale's `data.win` file into `game.unx`, and drag it and the other aforementioned files into the same folder as mentioned above.",
         "genres": [
             "rpg"
         ],


### PR DESCRIPTION
Discovered upon experimentation that the "game.unx" file that Undertale Linux uses can simply just be replaced with the "data.win" file that Undertale Windows uses. Seeing as how this pretty much negates the need for a Linux version, I've rewritten the instructions to help streamline the process for non-Linux users.