### PR TITLE
Fix quit to main menu for maxdownforce on digital control mode

### DIFF
--- a/ports/maxdownforce/maxdownforce/maxdownforce.gptk
+++ b/ports/maxdownforce/maxdownforce/maxdownforce.gptk
@@ -1,5 +1,5 @@
-guide = \"
-back = \"
+guide = esc
+back = esc
 start = space
 
 a = up


### PR DESCRIPTION
The game uses gptk mapping on digital controls mode (this mode is used for devices with less than 2 sticks because native gamepad support requires 2 sticks) and it is impossible quit to menu on it. To fix this I removed gamepad mapping for SELECT buttons from the game (to prevent double command input) and mapped it to esc 