### PR TITLE
Fix Serious Sam issue on ROCKNIX, add control scheme for trigger devices

### DIFF
--- a/ports/serioussam-tfe/Serious Sam - The First Encounter.sh
+++ b/ports/serioussam-tfe/Serious Sam - The First Encounter.sh
@@ -50,7 +50,6 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 if [ "$LIBGL_FB" != "" ]; then
   export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
-  export LIBGL_ES=1
   export LIBGL_GL=14
 fi
 

--- a/ports/serioussam-tfe/Serious Sam - The First Encounter.sh
+++ b/ports/serioussam-tfe/Serious Sam - The First Encounter.sh
@@ -14,22 +14,26 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 export PORT_32BIT="Y"
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
-GAMEDIR=/$directory/ports/sstfe/
-> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
+#GAMEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/sstfe"
+GAMEDIR="/$directory/ports/sstfe"
 
-$ESUDO chmod ugo+rwx -R $GAMEDIR/*
-$ESUDO chmod ugo+rwx $GAMEDIR/../*.sh
+if [ $DEVICE_NAME == 'x55' ] || [ $DEVICE_NAME == 'RG353P' ]; then
+    GPTOKEYB_CONFIG="$GAMEDIR/serioussamtriggers.gptk"  
+else
+    GPTOKEYB_CONFIG="$GAMEDIR/serioussam.gptk"
+fi
+
+$ESUDO chmod 777 $GAMEDIR/*
 
 cd $GAMEDIR
 
-# system
-export LD_LIBRARY_PATH=$GAMEDIR/Bin/libs:/usr/lib32:$LD_LIBRARY_PATH
+> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
 $ESUDO chmod 666 /dev/tty0
 $ESUDO chmod 666 /dev/tty1
@@ -41,15 +45,16 @@ else
   source "${controlfolder}/libgl_default.txt"
 fi
 
-if [ "$LIBGL_FB" != "" ]; then
-export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
-export LIBGL_ES=1
-export LIBGL_GL=14
-fi 
-
+export LD_LIBRARY_PATH="$GAMEDIR/Bin/libs:/usr/lib32:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-$GPTOKEYB "ssam-tfe" -c "$GAMEDIR/serioussam.gptk" &
+export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
+#if [ "$LIBGL_FB" != "" ] && [ "$CFW_NAME" != 'ROCKNIX' ]; then
+  export LIBGL_ES=1
+  export LIBGL_GL=14
+#fi
+
+$GPTOKEYB "ssam-tfe" -c "$GPTOKEYB_CONFIG" &
 $GAMEDIR/Bin/ssam-tfe
 
 $ESUDO kill -9 $(pidof gptokeyb)

--- a/ports/serioussam-tfe/Serious Sam - The First Encounter.sh
+++ b/ports/serioussam-tfe/Serious Sam - The First Encounter.sh
@@ -48,11 +48,11 @@ fi
 export LD_LIBRARY_PATH="$GAMEDIR/Bin/libs:/usr/lib32:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
-#if [ "$LIBGL_FB" != "" ] && [ "$CFW_NAME" != 'ROCKNIX' ]; then
+if [ "$LIBGL_FB" != "" ]; then
+  export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
   export LIBGL_ES=1
   export LIBGL_GL=14
-#fi
+fi
 
 $GPTOKEYB "ssam-tfe" -c "$GPTOKEYB_CONFIG" &
 $GAMEDIR/Bin/ssam-tfe

--- a/ports/serioussam-tfe/sstfe/serioussam.gptk
+++ b/ports/serioussam-tfe/sstfe/serioussam.gptk
@@ -31,10 +31,6 @@ right_analog_right = mouse_movement_right
 
 r3 = home
 
-//deadzone_triggers = 0
 mouse_scale = 6144
 
 mouse_delay = 16
-
-//deadzone_y = 2100
-//deadzone_x = 1900

--- a/ports/serioussam-tfe/sstfe/serioussamtriggers.gptk
+++ b/ports/serioussam-tfe/sstfe/serioussamtriggers.gptk
@@ -31,10 +31,6 @@ right_analog_right = mouse_movement_right
 
 r3 = home
 
-//deadzone_triggers = 0
 mouse_scale = 6144
 
 mouse_delay = 16
-
-//deadzone_y = 2100
-//deadzone_x = 1900

--- a/ports/serioussam-tfe/sstfe/serioussamtriggers.gptk
+++ b/ports/serioussam-tfe/sstfe/serioussamtriggers.gptk
@@ -1,0 +1,40 @@
+back = esc
+start = enter
+
+a = .
+b = ,
+x = e
+y = c
+
+l2 = space
+l1 = esc
+
+r1 = leftalt
+r2 = mouse_left
+
+up = up
+down = down
+left = left
+right = right
+
+left_analog_up = w
+left_analog_down = s
+left_analog_left = a
+left_analog_right = d
+
+l3 = tab
+
+right_analog_up = mouse_movement_up
+right_analog_down = mouse_movement_down
+right_analog_left = mouse_movement_left
+right_analog_right = mouse_movement_right
+
+r3 = home
+
+//deadzone_triggers = 0
+mouse_scale = 6144
+
+mouse_delay = 16
+
+//deadzone_y = 2100
+//deadzone_x = 1900

--- a/ports/serioussam-tse/Serious Sam - The Second Encounter.sh
+++ b/ports/serioussam-tse/Serious Sam - The Second Encounter.sh
@@ -14,44 +14,47 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
-export PORT_32BIT="Y"
 
+export PORT_32BIT="Y"
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
-GAMEDIR=/$directory/ports/sstse/
+#GAMEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/sstse"
+GAMEDIR="/$directory/ports/sstse"
 
-> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
+if [ $DEVICE_NAME == 'x55' ] || [ $DEVICE_NAME == 'RG353P' ]; then
+    GPTOKEYB_CONFIG="$GAMEDIR/serioussamtriggers.gptk"  
+else
+    GPTOKEYB_CONFIG="$GAMEDIR/serioussam.gptk"
+fi
 
-$ESUDO chmod ugo+rwx -R $GAMEDIR/*
-$ESUDO chmod ugo+rwx $GAMEDIR/../*.sh
+$ESUDO chmod 777 $GAMEDIR/*
 
 cd $GAMEDIR
 
-# system
-export LD_LIBRARY_PATH=$GAMEDIR/Bin/libs:/usr/lib32:$LD_LIBRARY_PATH
+> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
 $ESUDO chmod 666 /dev/tty0
 $ESUDO chmod 666 /dev/tty1
 $ESUDO chmod 666 /dev/uinput
 
-export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
-
-# gl4es
 if [ -f "${controlfolder}/libgl_${CFW_NAME}.txt" ]; then 
   source "${controlfolder}/libgl_${CFW_NAME}.txt"
 else
   source "${controlfolder}/libgl_default.txt"
 fi
 
-if [ "$LIBGL_FB" != "" ]; then
-export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
-export LIBGL_ES=1
-export LIBGL_GL=14
-fi 
+export LD_LIBRARY_PATH="$GAMEDIR/Bin/libs:/usr/lib32:$LD_LIBRARY_PATH"
+export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-$GPTOKEYB "ssam-tse" -c "$GAMEDIR/serioussam.gptk" &
+export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
+#if [ "$LIBGL_FB" != "" ] && [ "$CFW_NAME" != 'ROCKNIX' ]; then
+  export LIBGL_ES=1
+  export LIBGL_GL=14
+#fi
+
+$GPTOKEYB "ssam-tse" -c "$GPTOKEYB_CONFIG" &
 $GAMEDIR/Bin/ssam-tse
 
 $ESUDO kill -9 $(pidof gptokeyb)

--- a/ports/serioussam-tse/Serious Sam - The Second Encounter.sh
+++ b/ports/serioussam-tse/Serious Sam - The Second Encounter.sh
@@ -50,7 +50,6 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 if [ "$LIBGL_FB" != "" ]; then
   export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
-  export LIBGL_ES=1
   export LIBGL_GL=14
 fi
 

--- a/ports/serioussam-tse/Serious Sam - The Second Encounter.sh
+++ b/ports/serioussam-tse/Serious Sam - The Second Encounter.sh
@@ -48,11 +48,11 @@ fi
 export LD_LIBRARY_PATH="$GAMEDIR/Bin/libs:/usr/lib32:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
-#if [ "$LIBGL_FB" != "" ] && [ "$CFW_NAME" != 'ROCKNIX' ]; then
+if [ "$LIBGL_FB" != "" ]; then
+  export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
   export LIBGL_ES=1
   export LIBGL_GL=14
-#fi
+fi
 
 $GPTOKEYB "ssam-tse" -c "$GPTOKEYB_CONFIG" &
 $GAMEDIR/Bin/ssam-tse

--- a/ports/serioussam-tse/sstse/serioussam.gptk
+++ b/ports/serioussam-tse/sstse/serioussam.gptk
@@ -31,10 +31,6 @@ right_analog_right = mouse_movement_right
 
 r3 = home
 
-//deadzone_triggers = 0
 mouse_scale = 6144
 
 mouse_delay = 16
-
-//deadzone_y = 2100
-//deadzone_x = 1900

--- a/ports/serioussam-tse/sstse/serioussamtriggers.gptk
+++ b/ports/serioussam-tse/sstse/serioussamtriggers.gptk
@@ -31,10 +31,6 @@ right_analog_right = mouse_movement_right
 
 r3 = home
 
-//deadzone_triggers = 0
 mouse_scale = 6144
 
 mouse_delay = 16
-
-//deadzone_y = 2100
-//deadzone_x = 1900

--- a/ports/serioussam-tse/sstse/serioussamtriggers.gptk
+++ b/ports/serioussam-tse/sstse/serioussamtriggers.gptk
@@ -1,0 +1,40 @@
+back = esc
+start = enter
+
+a = .
+b = ,
+x = e
+y = c
+
+l2 = space
+l1 = esc
+
+r1 = leftalt
+r2 = mouse_left
+
+up = up
+down = down
+left = left
+right = right
+
+left_analog_up = w
+left_analog_down = s
+left_analog_left = a
+left_analog_right = d
+
+l3 = 0
+
+right_analog_up = mouse_movement_up
+right_analog_down = mouse_movement_down
+right_analog_left = mouse_movement_left
+right_analog_right = mouse_movement_right
+
+r3 = home
+
+//deadzone_triggers = 0
+mouse_scale = 6144
+
+mouse_delay = 16
+
+//deadzone_y = 2100
+//deadzone_x = 1900


### PR DESCRIPTION
-Fix Serious Sam black screen on ROCKNIX
-Add control scheme for devices with triggers
-Removed LIBGL_ES setting so it defaults to 2 - minor graphical anomalies occur with this setting, but isn't game breaking and seems to work across all configurations.