### PR TITLE
Replaced all '|&' occurrances with more widely supported '2>&1 |'

### DIFF
--- a/ports/anodyne/Anodyne.sh
+++ b/ports/anodyne/Anodyne.sh
@@ -64,7 +64,7 @@ printf "\033c" > /dev/tty0
 echo "Loading... Please Wait." > /dev/tty0
 
 $GPTOKEYB "mono" &
-$TASKSET mono --ffast-math -O=all ${gameassembly} |& tee ${gamedir}/log.txt
+$TASKSET mono --ffast-math -O=all ${gameassembly} 2>&1 | tee ${gamedir}/log.txt
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 $ESUDO umount "$monodir"

--- a/ports/bleed/Bleed.sh
+++ b/ports/bleed/Bleed.sh
@@ -53,23 +53,23 @@ regen_checksum=no
 
 sha1sum -c "${gamedir}/gamedata/.ver_checksum"
 if [ $? -ne 0 ]; then
-	echo "Checksum fail or unpatched binary found, patching game..." |& tee /dev/tty0
+	echo "Checksum fail or unpatched binary found, patching game..." 2>&1 | tee /dev/tty0
 	rm -f "${gamedir}/gamedata/.patch_done"
 fi
 
 # MONOMODDED files not found, let's perform patching
 if [[ ! -f "${gamedir}/gamedata/.patch_done" ]]; then
-	echo "Performing game patching..." |& tee /dev/tty0 "${gamedir}/install_log.txt"
+	echo "Performing game patching..." 2>&1 | tee /dev/tty0 "${gamedir}/install_log.txt"
 
 	# Configure MonoMod settings
 	export MONOMOD_MODS="$gamedir/patches"
 	export MONOMOD_DEPDIRS="${MONO_PATH}":"${gamedir}/monomod"
 
 	# Patch the ParisEngine/gameassembly files
-	mono "${gamedir}/monomod/MonoMod.RuntimeDetour.HookGen.exe" "${gamedir}/gamedata/Bleed.exe" |& tee -a /dev/tty0 "${gamedir}/install_log.txt"
-	mono "${gamedir}/monomod/MonoMod.exe" "${gamedir}/gamedata/Bleed.exe" |& tee -a /dev/tty0 "${gamedir}/install_log.txt"
+	mono "${gamedir}/monomod/MonoMod.RuntimeDetour.HookGen.exe" "${gamedir}/gamedata/Bleed.exe" 2>&1 | tee -a /dev/tty0 "${gamedir}/install_log.txt"
+	mono "${gamedir}/monomod/MonoMod.exe" "${gamedir}/gamedata/Bleed.exe" 2>&1 | tee -a /dev/tty0 "${gamedir}/install_log.txt"
 	if [ $? -ne 0 ]; then
-		echo "Failure performing first time setup, report this." |& tee -a /dev/tty0 "${gamedir}/install_log.txt"
+		echo "Failure performing first time setup, report this." 2>&1 | tee -a /dev/tty0 "${gamedir}/install_log.txt"
 		exit -1
 	fi
 
@@ -85,7 +85,7 @@ if [[ x${regen_checksum} -eq xyes ]]; then
 fi
 
 $GPTOKEYB "mono" &
-$TASKSET mono --ffast-math -O=all MONOMODDED_${gameassembly} |& tee /dev/tty0 "${gamedir}/log.txt"
+$TASKSET mono --ffast-math -O=all MONOMODDED_${gameassembly} 2>&1 | tee /dev/tty0 "${gamedir}/log.txt"
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 $ESUDO umount "$monodir"

--- a/ports/bleed2/Bleed2.sh
+++ b/ports/bleed2/Bleed2.sh
@@ -53,7 +53,7 @@ export FNA3D_OPENGL_FORCE_ES3=1
 export FNA3D_OPENGL_FORCE_VBO_DISCARD=1
 
 $GPTOKEYB "mono" &
-$TASKSET mono --ffast-math -O=all ${gameassembly} |& tee /dev/tty0 "${gamedir}/log.txt"
+$TASKSET mono --ffast-math -O=all ${gameassembly} 2>&1 | tee /dev/tty0 "${gamedir}/log.txt"
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 $ESUDO umount "$monodir"

--- a/ports/chasm/Chasm.sh
+++ b/ports/chasm/Chasm.sh
@@ -52,7 +52,7 @@ export FNA3D_FORCE_DRIVER=OpenGL
 export FNA3D_OPENGL_FORCE_ES3=1
 
 $GPTOKEYB "mono" &
-$TASKSET mono $gameassembly |& tee "$gamedir/log.txt" /dev/tty0
+$TASKSET mono $gameassembly 2>&1 | tee "$gamedir/log.txt" /dev/tty0
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 $ESUDO umount "$monodir"

--- a/ports/panzerpaladin/PanzerPaladin.sh
+++ b/ports/panzerpaladin/PanzerPaladin.sh
@@ -57,17 +57,17 @@ export FNA_SDL2_FORCE_BASE_PATH=0
 
 # Not patched? let's perform first time setup
 if [[ ! -f "$gamedir/gamedata/MONOMODDED_ParisEngine.dll" ]]; then	
-	echo "Performing first time setup..." |& tee /dev/tty0 "${gamedir}/install_log.txt"
-	echo "This may take upwards of 5 minutes, please wait." |& tee -a /dev/tty0 "${gamedir}/install_log.txt"
+	echo "Performing first time setup..." 2>&1 | tee /dev/tty0 "${gamedir}/install_log.txt"
+	echo "This may take upwards of 5 minutes, please wait." 2>&1 | tee -a /dev/tty0 "${gamedir}/install_log.txt"
 
 	# Configure MonoMod settings
 	export MONOMOD_MODS="$gamedir/patches"
 	export MONOMOD_DEPDIRS="${MONO_PATH}":"${gamedir}/monomod"
 
 	# Patch the ParisEngine file
-	mono "${gamedir}/monomod/MonoMod.exe" "${gamedir}/gamedata/ParisEngine.dll" |& tee -a /dev/tty0 "${gamedir}/install_log.txt"
+	mono "${gamedir}/monomod/MonoMod.exe" "${gamedir}/gamedata/ParisEngine.dll" 2>&1 | tee -a /dev/tty0 "${gamedir}/install_log.txt"
 	if [ $? -ne 0 ]; then
-		echo "Failure performing first time setup, report this." |& tee -a /dev/tty0 "${gamedir}/install_log.txt"
+		echo "Failure performing first time setup, report this." 2>&1 | tee -a /dev/tty0 "${gamedir}/install_log.txt"
 		exit -1
 	fi
 fi
@@ -76,7 +76,7 @@ printf "\033c" > /dev/tty0
 echo "Loading... Please Wait." > /dev/tty0
 
 $GPTOKEYB "mono" &
-$TASKSET mono --ffast-math -O=all ../MMLoader.exe ${gameassembly} |& tee /dev/tty0 "${gamedir}/log.txt"
+$TASKSET mono --ffast-math -O=all ../MMLoader.exe ${gameassembly} 2>&1 | tee /dev/tty0 "${gamedir}/log.txt"
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 $ESUDO umount "$monodir"

--- a/ports/savant/Savant Ascent.sh
+++ b/ports/savant/Savant Ascent.sh
@@ -59,7 +59,7 @@ $GPTOKEYB "gmloader" &
 echo "Loading, please wait... " > /dev/tty0
 
 # Run the game
-./gmloader savant.apk |& tee log.txt /dev/tty0
+./gmloader savant.apk 2>&1 | tee log.txt /dev/tty0
 
 # Kill proccesses & restart services
 $ESUDO kill -9 "$(pidof gptokeyb)"

--- a/ports/simonsqrev/Simon'sQuestRevamped.sh
+++ b/ports/simonsqrev/Simon'sQuestRevamped.sh
@@ -54,7 +54,7 @@ echo "Loading, please wait... " > /dev/tty0
 $ESUDO chmod +x "$GAMEDIR/gmloader"
 
 
-./gmloader simons_quest_revamped.apk |& tee log.txt /dev/tty0
+./gmloader simons_quest_revamped.apk 2>&1 | tee log.txt /dev/tty0
 
 $ESUDO kill -9 "$(pidof gptokeyb)"
 $ESUDO systemctl restart oga_events &

--- a/ports/tmntsr/TMNTShreddersRevenge.sh
+++ b/ports/tmntsr/TMNTShreddersRevenge.sh
@@ -58,7 +58,7 @@ export FNA_SDL2_FORCE_BASE_PATH=0
 
 sha1sum -c "${gamedir}/gamedata/.ver_checksum"
 if [ $? -ne 0 ]; then
-	echo "Checksum fail or unpatched binary found, patching game..." |& tee /dev/tty0
+	echo "Checksum fail or unpatched binary found, patching game..." 2>&1 | tee /dev/tty0
 	rm -f "${gamedir}/gamedata/.astc_done"
 	rm -f "${gamedir}/gamedata/.patch_done"
 fi
@@ -84,7 +84,7 @@ printf "\033c" > /dev/tty0
 echo "Loading... Please Wait." > /dev/tty0
 
 $GPTOKEYB "mono" &
-$TASKSET mono --ffast-math -O=all ../MMLoader.exe MONOMODDED_${gameassembly} |& tee ${gamedir}/log.txt
+$TASKSET mono --ffast-math -O=all ../MMLoader.exe MONOMODDED_${gameassembly} 2>&1 | tee ${gamedir}/log.txt
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 $ESUDO umount "$monodir"

--- a/ports/ubermoshcollection/UbermoshCollection.sh
+++ b/ports/ubermoshcollection/UbermoshCollection.sh
@@ -29,7 +29,7 @@ $ESUDO chmod 666 /dev/uinput
 $GPTOKEYB "gameselector" -c "selector.gptk" &
 echo "Loading, please wait... " > /dev/tty0
 
-./gameselector |& tee log.txt /dev/tty0
+./gameselector 2>&1 | tee log.txt /dev/tty0
 
 $ESUDO kill -9 "$(pidof gptokeyb)"
 $ESUDO systemctl restart oga_events &


### PR DESCRIPTION
Some handhelds that don't have a 'real' bash shell but some other sh compatible shell don't support the shorthand notation of '|&'.

Change to the equivalent but more widely supported '2>&1 |' notation.