### PR TITLE
sneggpit: fix rocknix 480x320 display

### DIFF
--- a/ports/sneggpit/sneggpit/manifest.json
+++ b/ports/sneggpit/sneggpit/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name":"sneggpit",
 	"start_url": "./",
-	"display": "standalone",
+	"display": "fullscreen",
 	"icon": "snegg_icon.svg",
 	"icons": [ { "src":"snegg_icon.svg", "sizes":"any" }, {"src":"snegg_icon.png", "sizes":"140x140", "type":"image/png"} ],
 	"window_width": 640,


### PR DESCRIPTION
Fixing a regression for the 480x320 screen resolution on certain CFWs, possibly present for all resolutions below 640x480