### PR TITLE
Symlink World of Goo save data into port directory

### DIFF
--- a/ports/worldofgoo/World of Goo.sh
+++ b/ports/worldofgoo/World of Goo.sh
@@ -46,6 +46,16 @@ fi
 export LD_LIBRARY_PATH="$GAMEDIR/box64/native":"/usr/lib":"/usr/lib/aarch64-linux-gnu/":"$GAMEDIR/libs/":"$LD_LIBRARY_PATH"
 export BOX64_LD_LIBRARY_PATH="$GAMEDIR/box64/x64":"$GAMEDIR/box64/native":"$GAMEDIR/libs/x64"
 
+# Move existing savedata to the port directory to avoid overwriting existing
+# saves. (Previous versions of the port didn't symlink savedata.)
+if [ -d ~/.WorldOfGoo ] && [ ! -h ~/.WorldOfGoo ]; then
+    $ESUDO cp -RT ~/.WorldOfGoo "$GAMEDIR/savedata"
+fi
+
+# Setup savedir
+$ESUDO rm -rf ~/.WorldOfGoo
+ln -sfv "$GAMEDIR/savedata" ~/.WorldOfGoo
+
 if [ "$LIBGL_FB" != "" ]; then
 export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es.aarch64/libGL.so.1"
 fi 


### PR DESCRIPTION
Fixes #556.

This makes the World of Goo port consistent with most of the others by keeping its save data in a `savedata` subdirectory under `ports/worldofgoo`. This makes it easier to back up the save data and keeps it from getting deleted on firmware updates (which will likely wipe out the home directory).

Since existing users will already have save data in `~/.WorldOfGoo`, we copy that data into the `savedata` directory rather than just overwriting it.