### PR TITLE
Set "Ready to run" to false at the "sdlpal" port.

### DIFF
--- a/ports/sdlpal/port.json
+++ b/ports/sdlpal/port.json
@@ -18,7 +18,7 @@
       "rpg"
     ],
     "image": {},
-    "rtr": true,
+    "rtr": false,
     "runtime": null,
     "reqs": [],
     "arch": [


### PR DESCRIPTION
Set `Ready to run` (rtr) to `false` at "sdlpal" port.