### PR TITLE
Update FPS scripts to additionally detect RG40XX as device with triggers

### DIFF
--- a/ports/duke3dawo/Duke3D - Alien World Order.sh
+++ b/ports/duke3dawo/Duke3D - Alien World Order.sh
@@ -66,7 +66,7 @@ else
   fi
 fi
 
-if [ $DEVICE_NAME == 'x55' ] || [ $DEVICE_NAME == 'RG353P' ]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/eduke32triggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/eduke32.gptk"

--- a/ports/hexen2/Hexen 2 - Portal of Praevus.sh
+++ b/ports/hexen2/Hexen 2 - Portal of Praevus.sh
@@ -42,7 +42,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
-if [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/hexen2triggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/hexen2.gptk"

--- a/ports/hexen2/Hexen 2.sh
+++ b/ports/hexen2/Hexen 2.sh
@@ -42,7 +42,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
-if [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/hexen2triggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/hexen2.gptk"

--- a/ports/kenslabyrinth/Ken's Labyrinth.sh
+++ b/ports/kenslabyrinth/Ken's Labyrinth.sh
@@ -22,9 +22,9 @@ GAMEDIR="/$directory/ports/kenslabyrinth"
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
 if [ $ANALOG_STICKS == '1' ]; then
-    GPTOKEYB_CONFIG="$GAMEDIR/ken1joy.gptk"  
-elif [ $DEVICE_NAME == 'x55' ] || [ $DEVICE_NAME == 'RG353P' ]; then
-    GPTOKEYB_CONFIG="$GAMEDIR/kentriggers.gptk"  
+    GPTOKEYB_CONFIG="$GAMEDIR/ken1joy.gptk"
+elif [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
+    GPTOKEYB_CONFIG="$GAMEDIR/kentriggers.gptk"
 else
     GPTOKEYB_CONFIG="$GAMEDIR/ken.gptk"
 fi

--- a/ports/quakespasm/Quakespasm - Aftershock.sh
+++ b/ports/quakespasm/Quakespasm - Aftershock.sh
@@ -38,7 +38,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
-if [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasmtriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasm.gptk"

--- a/ports/quakespasm/Quakespasm - Arcane Dimensions.sh
+++ b/ports/quakespasm/Quakespasm - Arcane Dimensions.sh
@@ -38,7 +38,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
-if [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasmtriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasm.gptk"

--- a/ports/quakespasm/Quakespasm - Dimension of the Machine.sh
+++ b/ports/quakespasm/Quakespasm - Dimension of the Machine.sh
@@ -38,7 +38,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
-if [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasmtriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasm.gptk"

--- a/ports/quakespasm/Quakespasm - Dimension of the Past.sh
+++ b/ports/quakespasm/Quakespasm - Dimension of the Past.sh
@@ -38,7 +38,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
-if [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasmtriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasm.gptk"

--- a/ports/quakespasm/Quakespasm - Dissolution of Eternity.sh
+++ b/ports/quakespasm/Quakespasm - Dissolution of Eternity.sh
@@ -38,7 +38,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
-if [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasmtriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasm.gptk"

--- a/ports/quakespasm/Quakespasm - Insomnia.sh
+++ b/ports/quakespasm/Quakespasm - Insomnia.sh
@@ -38,7 +38,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
-if [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasmtriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasm.gptk"

--- a/ports/quakespasm/Quakespasm - QZone.sh
+++ b/ports/quakespasm/Quakespasm - QZone.sh
@@ -38,7 +38,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
-if [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasmtriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasm.gptk"

--- a/ports/quakespasm/Quakespasm - Quake.sh
+++ b/ports/quakespasm/Quakespasm - Quake.sh
@@ -38,7 +38,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
-if [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasmtriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasm.gptk"

--- a/ports/quakespasm/Quakespasm - Scourge of Armagon.sh
+++ b/ports/quakespasm/Quakespasm - Scourge of Armagon.sh
@@ -38,7 +38,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
-if [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasmtriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/quakespasm.gptk"

--- a/ports/serioussam-tfe/Serious Sam - The First Encounter.sh
+++ b/ports/serioussam-tfe/Serious Sam - The First Encounter.sh
@@ -23,7 +23,7 @@ get_controls
 #GAMEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/sstfe"
 GAMEDIR="/$directory/ports/sstfe"
 
-if [ $DEVICE_NAME == 'x55' ] || [ $DEVICE_NAME == 'RG353P' ]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/serioussamtriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/serioussam.gptk"

--- a/ports/serioussam-tse/Serious Sam - The Second Encounter.sh
+++ b/ports/serioussam-tse/Serious Sam - The Second Encounter.sh
@@ -23,7 +23,7 @@ get_controls
 #GAMEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/sstse"
 GAMEDIR="/$directory/ports/sstse"
 
-if [ $DEVICE_NAME == 'x55' ] || [ $DEVICE_NAME == 'RG353P' ]; then
+if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/serioussamtriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/serioussam.gptk"


### PR DESCRIPTION
Also, ChatGPT handed me something interesting...
"${DEVICE_NAME^^}"
This will read the value of the DEVICE_NAME envar and if it's in lowercase, it will be converted to uppercase prior to checking the entry which eliminates case sensitivity interfering with these checks.  Pretty cool, pretty cool, heh heh.
Kloptops already addressed making sure devices get set in all caps for this, but just in case that a device/CFW returns a lowercase value for some strange reason...
I'm also fully aware that PortMaster is what sets this envar in its entirety, but I figured if I can make it more robust... why not do so?