### PR TITLE
fix camera jumping in minetest for rocknix (bug fix)

### DIFF
--- a/ports/minetest/Minetest.sh
+++ b/ports/minetest/Minetest.sh
@@ -57,9 +57,15 @@ fi
 
 [ "$CFW_NAME" = "AmberELEC" -o "$CFW_NAME" = "muOS" ] && [ -f "$GAMEDIR/libs.$DEVICE_ARCH/libcurl.so.4" ] && rm -f "$GAMEDIR/libs.$DEVICE_ARCH/libcurl.so.4"
 ifconfig lo up
+if [ "$CFW_NAME" = "ROCKNIX" ]; then
+	swaymsg seat seat0 hide_cursor 0
+fi
 chmod +x ./bin/minetest
 $GPTOKEYB "minetest" -c "$GAMEDIR/minetest.gptk.$ANALOG_STICKS" &
 ./bin/minetest
+if [ "$CFW_NAME" = "ROCKNIX" ]; then
+	swaymsg seat seat0 hide_cursor 1000
+fi
 
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &


### PR DESCRIPTION
not a new port, just a bug fix for an existing port
honestly i dont know if the checks for rocknix are necessary i just thought they'd be good to include
thanks TheWalkingTaco for finding the problem
i did double check and this does solve the problem, the camera no longer randomly jumps after holding it still for too long