### PR TITLE
SDL_GAMECONTROLLERCONFIG fix for Cataclysm DDA.sh 

### DIFF
--- a/ports/cataclysm-dda/Cataclysm DDA.sh
+++ b/ports/cataclysm-dda/Cataclysm DDA.sh
@@ -25,13 +25,14 @@ mkdir -p "$GAMEDIR/conf"
 # Set the XDG environment variables for config & savefiles
 export XDG_CONFIG_HOME="$CONFDIR"
 export XDG_DATA_HOME="$CONFDIR"
+export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 cd $GAMEDIR
 
 
 $ESUDO chmod 666 /dev/uinput
 $GPTOKEYB "cataclysm-tiles" -c "cataclysm.gptk" &
-SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig" ./cataclysm-tiles 2>&1 | tee $GAMEDIR/log.txt
+./cataclysm-tiles 2>&1 | tee $GAMEDIR/log.txt
 
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &


### PR DESCRIPTION
SDL_GAMECONTROLLERCONFIG was exported wrong way so knulli had reversed A-B X-Y buttons