### PR TITLE
Update RA Config Path for muOS Banana

### DIFF
--- a/ports/2048/2048.sh
+++ b/ports/2048/2048.sh
@@ -28,11 +28,12 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="--config /run/muos/storage/info/config/retroarch.cfg"
-else
-  raloc="/usr/bin"
-  raconf=""
-fi
+  if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
+    raconf="--config /run/muos/storage/info/config/retroarch.cfg"
+  else
+    raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  fi
+
 
 GAMEDIR="/$directory/ports/2048"
 

--- a/ports/2048/2048.sh
+++ b/ports/2048/2048.sh
@@ -35,7 +35,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   fi
 else
   raloc="/usr/bin"
-  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf=""
 fi
 
 GAMEDIR="/$directory/ports/2048"

--- a/ports/2048/2048.sh
+++ b/ports/2048/2048.sh
@@ -33,7 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
-
+else
+  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+fi
 
 GAMEDIR="/$directory/ports/2048"
 

--- a/ports/2048/2048.sh
+++ b/ports/2048/2048.sh
@@ -28,7 +28,7 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf="--config /run/muos/storage/info/config/retroarch.cfg"
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/2048/2048.sh
+++ b/ports/2048/2048.sh
@@ -34,6 +34,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
 else
+  raloc="/usr/bin"
   raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
 fi
 

--- a/ports/cannonball-lr/Cannonball.sh
+++ b/ports/cannonball-lr/Cannonball.sh
@@ -35,7 +35,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   fi
 else
   raloc="/usr/bin"
-  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf=""
 fi
 
 GAMEDIR="/$directory/ports/cannonball"

--- a/ports/cannonball-lr/Cannonball.sh
+++ b/ports/cannonball-lr/Cannonball.sh
@@ -28,7 +28,7 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/cannonball-lr/Cannonball.sh
+++ b/ports/cannonball-lr/Cannonball.sh
@@ -28,11 +28,11 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
-else
-  raloc="/usr/bin"
-  raconf=""
-fi
+  if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
+    raconf="--config /run/muos/storage/info/config/retroarch.cfg"
+  else
+    raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  fi
 
 GAMEDIR="/$directory/ports/cannonball"
 

--- a/ports/cannonball-lr/Cannonball.sh
+++ b/ports/cannonball-lr/Cannonball.sh
@@ -33,6 +33,10 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+else
+  raloc="/usr/bin"
+  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+fi
 
 GAMEDIR="/$directory/ports/cannonball"
 

--- a/ports/cave.story/Cave Story.sh
+++ b/ports/cave.story/Cave Story.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+else
+  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+fi
 
 GAMEDIR="/$directory/ports/cavestory"
 

--- a/ports/cave.story/Cave Story.sh
+++ b/ports/cave.story/Cave Story.sh
@@ -28,11 +28,11 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
-else
-  raloc="/usr/bin"
-  raconf=""
-fi
+  if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
+    raconf="--config /run/muos/storage/info/config/retroarch.cfg"
+  else
+    raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  fi
 
 GAMEDIR="/$directory/ports/cavestory"
 

--- a/ports/cave.story/Cave Story.sh
+++ b/ports/cave.story/Cave Story.sh
@@ -28,7 +28,7 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/cave.story/Cave Story.sh
+++ b/ports/cave.story/Cave Story.sh
@@ -35,7 +35,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   fi
 else
   raloc="/usr/bin"
-  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf=""
 fi
 
 GAMEDIR="/$directory/ports/cavestory"

--- a/ports/cave.story/Cave Story.sh
+++ b/ports/cave.story/Cave Story.sh
@@ -34,6 +34,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
 else
+  raloc="/usr/bin"
   raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
 fi
 

--- a/ports/dinothawr/Dinothawr.sh
+++ b/ports/dinothawr/Dinothawr.sh
@@ -35,7 +35,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   fi
 else
   raloc="/usr/bin"
-  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf=""
 fi
 
 GAMEDIR="/$directory/ports/dinothawr"

--- a/ports/dinothawr/Dinothawr.sh
+++ b/ports/dinothawr/Dinothawr.sh
@@ -28,11 +28,11 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
-else
-  raloc="/usr/bin"
-  raconf=""
-fi
+  if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
+    raconf="--config /run/muos/storage/info/config/retroarch.cfg"
+  else
+    raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  fi
 
 GAMEDIR="/$directory/ports/dinothawr"
 

--- a/ports/dinothawr/Dinothawr.sh
+++ b/ports/dinothawr/Dinothawr.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+else
+  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+fi
 
 GAMEDIR="/$directory/ports/dinothawr"
 

--- a/ports/dinothawr/Dinothawr.sh
+++ b/ports/dinothawr/Dinothawr.sh
@@ -28,7 +28,7 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/dinothawr/Dinothawr.sh
+++ b/ports/dinothawr/Dinothawr.sh
@@ -34,6 +34,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
 else
+  raloc="/usr/bin"
   raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
 fi
 

--- a/ports/mr.boom/Mr. Boom.sh
+++ b/ports/mr.boom/Mr. Boom.sh
@@ -35,7 +35,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   fi
 else
   raloc="/usr/bin"
-  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf=""
 fi
 
 GAMEDIR="/$directory/ports/mrboom"

--- a/ports/mr.boom/Mr. Boom.sh
+++ b/ports/mr.boom/Mr. Boom.sh
@@ -28,7 +28,7 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/mr.boom/Mr. Boom.sh
+++ b/ports/mr.boom/Mr. Boom.sh
@@ -28,11 +28,11 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
-else
-  raloc="/usr/bin"
-  raconf=""
-fi
+  if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
+    raconf="--config /run/muos/storage/info/config/retroarch.cfg"
+  else
+    raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  fi
 
 GAMEDIR="/$directory/ports/mrboom"
 

--- a/ports/mr.boom/Mr. Boom.sh
+++ b/ports/mr.boom/Mr. Boom.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+else
+  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+fi
 
 GAMEDIR="/$directory/ports/mrboom"
 

--- a/ports/mr.boom/Mr. Boom.sh
+++ b/ports/mr.boom/Mr. Boom.sh
@@ -34,6 +34,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
 else
+  raloc="/usr/bin"
   raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
 fi
 

--- a/ports/quake/Quake.sh
+++ b/ports/quake/Quake.sh
@@ -28,7 +28,7 @@ elif [[ $CFW_NAME == "ArkOS" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/quake/Quake.sh
+++ b/ports/quake/Quake.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+else
+  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+fi
 
 GAMEDIR="/$directory/ports/quake"
 

--- a/ports/quake/Quake.sh
+++ b/ports/quake/Quake.sh
@@ -28,11 +28,11 @@ elif [[ $CFW_NAME == "ArkOS" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
-else
-  raloc="/usr/bin"
-  raconf=""
-fi
+  if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
+    raconf="--config /run/muos/storage/info/config/retroarch.cfg"
+  else
+    raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  fi
 
 GAMEDIR="/$directory/ports/quake"
 

--- a/ports/quake/Quake.sh
+++ b/ports/quake/Quake.sh
@@ -35,7 +35,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   fi
 else
   raloc="/usr/bin"
-  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf=""
 fi
 
 GAMEDIR="/$directory/ports/quake"

--- a/ports/quake/Quake.sh
+++ b/ports/quake/Quake.sh
@@ -34,6 +34,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
 else
+  raloc="/usr/bin"
   raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
 fi
 

--- a/ports/rick.dangerous/Rick Dangerous.sh
+++ b/ports/rick.dangerous/Rick Dangerous.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+else
+  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+fi
 
 GAMEDIR="/$directory/ports/xrick"
 

--- a/ports/rick.dangerous/Rick Dangerous.sh
+++ b/ports/rick.dangerous/Rick Dangerous.sh
@@ -35,7 +35,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   fi
 else
   raloc="/usr/bin"
-  raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf=""
 fi
 
 GAMEDIR="/$directory/ports/xrick"

--- a/ports/rick.dangerous/Rick Dangerous.sh
+++ b/ports/rick.dangerous/Rick Dangerous.sh
@@ -28,11 +28,11 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
-else
-  raloc="/usr/bin"
-  raconf=""
-fi
+  if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
+    raconf="--config /run/muos/storage/info/config/retroarch.cfg"
+  else
+    raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  fi
 
 GAMEDIR="/$directory/ports/xrick"
 

--- a/ports/rick.dangerous/Rick Dangerous.sh
+++ b/ports/rick.dangerous/Rick Dangerous.sh
@@ -28,7 +28,7 @@ elif [[ $CFW_NAME == "ArkOS" ]] || [[ $CFW_NAME == "ArkOS wuMMLe" ]]; then
   raconf=""
 elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
-  raconf="-v -f -c /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  raconf="-v -f -c /run/muos/storage/info/config/retroarch.cfg"
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/rick.dangerous/Rick Dangerous.sh
+++ b/ports/rick.dangerous/Rick Dangerous.sh
@@ -34,6 +34,7 @@ elif [[ $CFW_NAME == "muOS" ]]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
 else
+  raloc="/usr/bin"
   raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
 fi
 


### PR DESCRIPTION
The RA config path changed in muOS Banana, this breaks controls for ports that use libretro cores.

This should fix that.

This should also work with the muOS change to allow RA configs to live elsewhere, as it uses the bind mount. But that has been pushed off to post-Banana anyway so will likely be a while before we need to worry about it.