### PR TITLE
Fix rtr flag for hydorah

### DIFF
--- a/ports/hydorah/README.md
+++ b/ports/hydorah/README.md
@@ -1,6 +1,7 @@
 ## Notes
-<br/>
 
+<br/>
 Thanks to [Locomalito, Gryzor87, Abylight](https://store.steampowered.com/app/628800/Super_Hydorah/) for creating this game.  Also thanks to Tekkenfede for the porting work for portmaster.
 <br/>
 
+Source: https://store.steampowered.com/app/628800/Super_Hydorah/

--- a/ports/hydorah/port.json
+++ b/ports/hydorah/port.json
@@ -2,7 +2,7 @@
     "version": 2,
     "name": "hydorah.zip",
     "items": [
-        "Hydorah/",
+        "Hydorah",
         "Hydorah.sh"
     ],
     "items_opt": null,
@@ -12,12 +12,12 @@
             "Tekkenfede"
         ],
         "desc": "Super Hydorah is a nonlinear horizontal shoot' em up designed to offer a challenging experience, sublimating the richness of traditional shmup classics.",
-        "inst": "Copy the data.win file and the texts and music folders inside gamedata. Then Boot the game from Hydorah.sh\n",
+        "inst": "Purchase and download the game on steam. Copy the data.win file and the texts and music folders inside gamedata. Then Boot the game from Hydorah.sh\n",
         "genres": [
             "arcade"
         ],
         "image": {},
-        "rtr": true,
+        "rtr": false,
         "runtime": null,
         "reqs": [],
         "arch": [


### PR DESCRIPTION
The port requires game files, so the 'ready to run' flag was incorrect. Additionally, the instructions were improved, and the folder name in the 'items' field was fixed.