### PR TITLE
Mini Doom II: Fix SDL_swap_gpbuttons.py for unsupported "extend" in python 3.7 for ArkOS

### DIFF
--- a/ports/minidoom2/Mini Doom II.sh
+++ b/ports/minidoom2/Mini Doom II.sh
@@ -40,6 +40,7 @@ $ESUDO chmod +x "$GAMEDIR/tools/oggdec"
 $ESUDO chmod +x "$GAMEDIR/tools/vgmstream-cli"
 $ESUDO chmod +x "$GAMEDIR/tools/wwise2audiogroup.py"
 
+
 cd $GAMEDIR
 
 # Functions BEGIN
@@ -48,11 +49,11 @@ swapabxy() {
 
     if [ "$CFW_NAME" == "knulli" ] && [ -f "$SDL_GAMECONTROLLERCONFIG_FILE" ];then
       # Knulli seems to use SDL_GAMECONTROLLERCONFIG_FILE (on rg40xxh at least)
-      SDL_swap_gpbuttons.py -i "$SDL_GAMECONTROLLERCONFIG_FILE" -o "$GAMEDIR/gamecontrollerdb_swapped.txt" $(<SDL_swap_gpbuttons.txt)
+      SDL_swap_gpbuttons.py -i "$SDL_GAMECONTROLLERCONFIG_FILE" -o "$GAMEDIR/gamecontrollerdb_swapped.txt" -l "$GAMEDIR/SDL_swap_gpbuttons.txt"
       export SDL_GAMECONTROLLERCONFIG_FILE="$GAMEDIR/gamecontrollerdb_swapped.txt"
     else
       # Other CFW use SDL_GAMECONTROLLERCONFIG
-      export SDL_GAMECONTROLLERCONFIG="`echo "$SDL_GAMECONTROLLERCONFIG" | SDL_swap_gpbuttons.py $(<SDL_swap_gpbuttons.txt)`"
+      export SDL_GAMECONTROLLERCONFIG="`echo "$SDL_GAMECONTROLLERCONFIG" | SDL_swap_gpbuttons.py -l "$GAMEDIR/SDL_swap_gpbuttons.txt"`"
     fi
 }
 # Functions END
@@ -76,6 +77,7 @@ if [ -f "$GAMEDIR/SDL_swap_gpbuttons.txt" ]; then
     swapabxy
 fi
 
+#$GPTOKEYB "gmloader" -c ./minidoom2.gptk &
 $GPTOKEYB "gmloadernext" &
 pm_plateform_helper "$GAMEDIR/gmloadernext"
 

--- a/ports/minidoom2/Mini Doom II.sh
+++ b/ports/minidoom2/Mini Doom II.sh
@@ -40,7 +40,6 @@ $ESUDO chmod +x "$GAMEDIR/tools/oggdec"
 $ESUDO chmod +x "$GAMEDIR/tools/vgmstream-cli"
 $ESUDO chmod +x "$GAMEDIR/tools/wwise2audiogroup.py"
 
-
 cd $GAMEDIR
 
 # Functions BEGIN
@@ -77,7 +76,6 @@ if [ -f "$GAMEDIR/SDL_swap_gpbuttons.txt" ]; then
     swapabxy
 fi
 
-#$GPTOKEYB "gmloader" -c ./minidoom2.gptk &
 $GPTOKEYB "gmloadernext" &
 pm_plateform_helper "$GAMEDIR/gmloadernext"
 

--- a/ports/minidoom2/minidoom2/SDL_swap_gpbuttons.txt
+++ b/ports/minidoom2/minidoom2/SDL_swap_gpbuttons.txt
@@ -1,1 +1,2 @@
-a b x y
+a b
+x y

--- a/ports/minidoom2/minidoom2/tools/SDL_swap_gpbuttons.py
+++ b/ports/minidoom2/minidoom2/tools/SDL_swap_gpbuttons.py
@@ -4,10 +4,10 @@ import argparse
 
 """
     name: swapabxy tool
-    description: swap a/b and x/y button in SDL_GAMECONTROLLERCONFIG
+    description: swap buttons in SDL_GAMECONTROLLERCONFIG
     author: kotzebuedog
     usage:
-        export SDL_GAMECONTROLLERCONFIG="`echo "$SDL_GAMECONTROLLERCONFIG" | ./swapabxy.py`"
+        export SDL_GAMECONTROLLERCONFIG="`echo "$SDL_GAMECONTROLLERCONFIG" | ./SDL_swap_gpbuttons.py -i - -o - -l swaplist.txt`"
 
     For example:
 
@@ -27,14 +27,21 @@ def main():
     parser = argparse.ArgumentParser(description='K-dog Gamepad button swapper tool: swap one or more pair of button in the SDL GAMECONTROLLER CONFIG')
     parser.add_argument('-i', '--input', default="-",help='SDL GAMECONTROLLER CONFIG input file (by default stdin)')
     parser.add_argument('-o', '--output', default="-",help='SDL GAMECONTROLLER CONFIG output file (by default stdout)')
-    parser.add_argument('swaplist', action="extend", nargs="+", type=str, help='list of pair of button to swap (eg. a b x y)')
+    parser.add_argument('-l', '--list-file',default="SDL_swap_gpbuttons.txt",help='Swap list file. 2-tuples of buttons to swap (eg. "a b" to swap a with b), one per line.')
 
     args = parser.parse_args()
 
     swaplist = []
-    # Setup a list of swap pairs
-    for i in range( len(args.swaplist) // 2 ):
-        swaplist.append(args.swaplist[ 2 * i : 2 * i + 2 ])
+    # Setup a list of swap 2-tuples
+    with open(args.list_file,'r') as list_file:
+        lines = list_file.readlines()
+        for _,line in enumerate(lines):
+            values = line.strip().split(' ')
+            if len(values) != 2:
+                # we skip this line
+                continue
+            else:
+                swaplist.append(values)
     
     if args.input != '-':
         with open(args.input, 'r') as inputfile:


### PR DESCRIPTION
ArkOS has python 3.7 which doesn't support the `extend` action in `argparse`. The game runs but the swap of the buttons isn't applied.