### PR TITLE
Sonic CD update

### DIFF
--- a/ports/sonic.1/Sonic 1.sh
+++ b/ports/sonic.1/Sonic 1.sh
@@ -14,17 +14,15 @@ fi
 
 source $controlfolder/control.txt
 get_controls
-
-# Source Device Info
-source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 # Set variables
 GAMEDIR="/$directory/ports/sonic1"
-WIDTH=$((DISPLAY_WIDTH / 2))
-> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
+# CD and set permissions
 cd $GAMEDIR
+> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
+$ESUDO chmod +x -R $GAMEDIR/*
 
 # Exports
 export LD_LIBRARY_PATH="/usr/lib:$GAMEDIR/libs":$LD_LIBRARY_PATH
@@ -37,33 +35,25 @@ else
   source "${controlfolder}/libgl_default.txt"
 fi
 
-# Permissions
-$ESUDO chmod 666 /dev/tty0
-$ESUDO chmod 666 /dev/tty1
-$ESUDO chmod 777 $GAMEDIR/sonic2013
-$ESUDO chmod 777 $GAMEDIR/sonicforever
-
 # Modify ScreenWidth
 LOW=214 # 3:2
 MED=320 # 4:3
 HIGH=426 # 16:9
 
-# Set WIDTH based on DISPLAY_WIDTH
-case $DISPLAY_WIDTH in
-  [0-2][0-9][0-9])  # 0 to 299 range
-    WIDTH=$LOW
-    ;;
-  [3-9][0-9][0-9])  # 300 to 999 range
-    WIDTH=$MED
-    ;;
-  [1-9][0-9][0-9][0-9])  # 1000 and above range
-    WIDTH=$HIGH
-    ;;
-  *)
-    echo "Unknown screen width: $DISPLAY_WIDTH"
-    WIDTH=$MED  # Default value or handle as needed
-    ;;
-esac
+# Calculate the aspect ratio with floating-point precision
+ASPECT=$(awk -v w="$DISPLAY_WIDTH" -v h="$DISPLAY_HEIGHT" 'BEGIN { printf "%.2f", w / h }')
+
+# Set WIDTH based on the calculated aspect ratio
+if (( $(echo "$ASPECT == 1.50" | bc -l) )); then
+    WIDTH=$LOW  # 3:2
+elif (( $(echo "$ASPECT == 1.33" | bc -l) )); then
+    WIDTH=$MED  # 4:3
+elif (( $(echo "$ASPECT == 1.78" | bc -l) )); then
+    WIDTH=$HIGH  # 16:9
+else
+    echo "Unknown aspect ratio: $ASPECT"
+    WIDTH=$MED  # Default value if aspect ratio is unknown
+fi
 
 if grep -q "^ScreenWidth=[0-9]\+" "$GAMEDIR/settings.ini"; then
     sed -i "s/^ScreenWidth=[0-9]\+/ScreenWidth=$WIDTH/" "$GAMEDIR/settings.ini"
@@ -83,8 +73,8 @@ fi
 # Run the game
 echo "Loading, please wait!" > $CUR_TTY
 $GPTOKEYB $GAME -c "sonic.gptk" &
+pm_platform_helper "$GAME"
 ./$GAME
 
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO systemctl restart oga_events &
-printf "\033c" > /dev/tty1
+# Cleanup
+pm_finish

--- a/ports/sonic.cd/Sonic CD.sh
+++ b/ports/sonic.cd/Sonic CD.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# PORTMASTER: sonic.cd.zip, Sonic CD.sh
 
 XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
 
@@ -14,20 +15,26 @@ fi
 
 source $controlfolder/control.txt
 get_controls
-
-# Source Device Info
-source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 # Set variables
 GAMEDIR="/$directory/ports/soniccd"
-> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
+# CD and set permissions
 cd $GAMEDIR
+> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
+$ESUDO chmod +x -R $GAMEDIR/*
 
 # Exports
 export LD_LIBRARY_PATH="$GAMEDIR/libs":$LD_LIBRARY_PATH
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
+
+# Setup gl4es environment
+if [ -f "${controlfolder}/libgl_${CFW_NAME}.txt" ]; then 
+  source "${controlfolder}/libgl_${CFW_NAME}.txt"
+else
+  source "${controlfolder}/libgl_default.txt"
+fi
 
 # Permissions
 $ESUDO chmod 666 /dev/tty0
@@ -39,22 +46,20 @@ LOW=214 # 3:2
 MED=320 # 4:3
 HIGH=426 # 16:9
 
-# Set WIDTH based on DISPLAY_WIDTH
-case $DISPLAY_WIDTH in
-  [0-3][0-9][0-9])  # 0 to 399 range
-    WIDTH=$LOW
-    ;;
-  [4-9][0-9][0-9])  # 400 to 999 range
-    WIDTH=$MED
-    ;;
-  [1-9][0-9][0-9][0-9])  # 1000 and above range
-    WIDTH=$HIGH
-    ;;
-  *)
-    echo "Unknown screen width: $DISPLAY_WIDTH"
-    WIDTH=$MED  # Default value or handle as needed
-    ;;
-esac
+# Calculate the aspect ratio with floating-point precision
+ASPECT=$(awk -v w="$DISPLAY_WIDTH" -v h="$DISPLAY_HEIGHT" 'BEGIN { printf "%.2f", w / h }')
+
+# Set WIDTH based on the calculated aspect ratio
+if (( $(echo "$ASPECT == 1.50" | bc -l) )); then
+    WIDTH=$LOW  # 3:2
+elif (( $(echo "$ASPECT == 1.33" | bc -l) )); then
+    WIDTH=$MED  # 4:3
+elif (( $(echo "$ASPECT == 1.78" | bc -l) )); then
+    WIDTH=$HIGH  # 16:9
+else
+    echo "Unknown aspect ratio: $ASPECT"
+    WIDTH=$MED  # Default value if aspect ratio is unknown
+fi
 
 if grep -q "^ScreenWidth=[0-9]\+" "$GAMEDIR/settings.ini"; then
     sed -i "s/^ScreenWidth=[0-9]\+/ScreenWidth=$WIDTH/" "$GAMEDIR/settings.ini"
@@ -63,10 +68,9 @@ else
 fi
 
 # Run the game
-echo "Loading, please wait!" > $CUR_TTY
 $GPTOKEYB "soniccd" -c "sonic.gptk" &
+pm_platform_helper "soniccd"
 ./soniccd
 
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO systemctl restart oga_events &
-printf "\033c" > /dev/tty1
+# Cleanup
+pm_finish

--- a/ports/sonic.cd/Sonic CD.sh
+++ b/ports/sonic.cd/Sonic CD.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# PORTMASTER: sonic.cd.zip, Sonic CD.sh
 
 XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
 


### PR DESCRIPTION
Previous version only relied on width to set up the ini file. Since the rpmini has a 1280x960 ratio, it would erroneously use the 16:9 setting. Fix that.