### PR TITLE
Update solarus ports

### DIFF
--- a/ports/hallowseve/Hallow's Eve.sh
+++ b/ports/hallowseve/Hallow's Eve.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 # Set variables
@@ -22,9 +23,10 @@ solarus_dir="$HOME/portmaster-solarus"
 solarus_file="$controlfolder/libs/${runtime}.squashfs"
 
 # Exports
-export LD_LIBRARY_PATH="$GAMEDIR/libs:$solarus_dir"
+export LD_LIBRARY_PATH="/usr/lib:$GAMEDIR/libs:$solarus_dir"
 
 cd $GAMEDIR
+> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
 # Check for runtime
 if [ ! -f "$controlfolder/libs/${runtime}.squashfs" ]; then
@@ -52,8 +54,6 @@ $GPTOKEYB "$runtime" -c "hallowseve.gptk" &
 # Run the game
 echo "Loading, please wait... (might take a while!)" > /dev/tty0
 "$runtime" $GAMEDIR/*.solarus 2>&1 | tee -a ./"log.txt"
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO umount "$solarus_file" || true
-$ESUDO systemctl restart oga_events & 
-printf "\033c" >> /dev/tty1
-printf "\033c" > /dev/tty0
+
+# Cleanup
+pm_finish

--- a/ports/oceansheart/Ocean's Heart.sh
+++ b/ports/oceansheart/Ocean's Heart.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -38,7 +37,7 @@ else
 fi
 
 # Exports
-export LD_LIBRARY_PATH="$GAMEDIR/libs:$solarus_dir"
+export LD_LIBRARY_PATH="/usr/lib:$GAMEDIR/libs:$solarus_dir"
 
 # Check for runtime
 if [ ! -f "$controlfolder/libs/${runtime}.squashfs" ]; then
@@ -66,8 +65,6 @@ $GPTOKEYB "$runtime" -c "oceansheart.gptk" &
 # Run the game
 echo "Loading, please wait... (might take a while!)" > /dev/tty0
 "$runtime" $GAMEDIR/*.solarus
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO umount "$solarus_file" || true
-$ESUDO systemctl restart oga_events & 
-printf "\033c" >> /dev/tty1
-printf "\033c" > /dev/tty0
+
+# Cleanup
+pm_finish

--- a/ports/osanasrevenge/Osana's Revenge.sh
+++ b/ports/osanasrevenge/Osana's Revenge.sh
@@ -1,17 +1,13 @@
 #!/bin/bash
 
-XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
-
+# Source SDL controls
 if [ -d "/opt/system/Tools/PortMaster/" ]; then
   controlfolder="/opt/system/Tools/PortMaster"
 elif [ -d "/opt/tools/PortMaster/" ]; then
   controlfolder="/opt/tools/PortMaster"
-elif [ -d "$XDG_DATA_HOME/PortMaster/" ]; then
-  controlfolder="$XDG_DATA_HOME/PortMaster"
 else
   controlfolder="/roms/ports/PortMaster"
 fi
-
 source $controlfolder/control.txt
 get_controls
 
@@ -22,7 +18,7 @@ solarus_dir="$HOME/portmaster-solarus"
 solarus_file="$controlfolder/libs/${runtime}.squashfs"
 
 # Exports
-export LD_LIBRARY_PATH="$GAMEDIR/libs:$solarus_dir"
+export LD_LIBRARY_PATH="/usr/lib:$GAMEDIR/libs:$solarus_dir"
 
 cd $GAMEDIR
 
@@ -53,7 +49,6 @@ $GPTOKEYB "$runtime" -c "osana.gptk" &
 echo "Loading, please wait... (might take a while!)" > /dev/tty0
 "$runtime" $GAMEDIR/*.solarus 2>&1 | tee -a ./"log.txt"
 $ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO umount "$solarus_file" || true
-$ESUDO systemctl restart oga_events & 
-printf "\033c" >> /dev/tty1
-printf "\033c" > /dev/tty0
+
+# Cleanup
+pm_finish

--- a/ports/yarntown/Yarntown.sh
+++ b/ports/yarntown/Yarntown.sh
@@ -1,17 +1,13 @@
 #!/bin/bash
 
-XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
-
+# Source SDL controls
 if [ -d "/opt/system/Tools/PortMaster/" ]; then
   controlfolder="/opt/system/Tools/PortMaster"
 elif [ -d "/opt/tools/PortMaster/" ]; then
   controlfolder="/opt/tools/PortMaster"
-elif [ -d "$XDG_DATA_HOME/PortMaster/" ]; then
-  controlfolder="$XDG_DATA_HOME/PortMaster"
 else
   controlfolder="/roms/ports/PortMaster"
 fi
-
 source $controlfolder/control.txt
 get_controls
 
@@ -22,7 +18,7 @@ solarus_dir="$HOME/portmaster-solarus"
 solarus_file="$controlfolder/libs/${runtime}.squashfs"
 
 # Exports
-export LD_LIBRARY_PATH="$GAMEDIR/libs:$solarus_dir"
+export LD_LIBRARY_PATH="/usr/lib:$GAMEDIR/libs:$solarus_dir"
 
 cd $GAMEDIR
 
@@ -53,7 +49,6 @@ $GPTOKEYB "$runtime" -c "yarntown.gptk" &
 echo "Loading, please wait... (might take a while!)" > /dev/tty0
 "$runtime" $GAMEDIR/*.solarus 2>&1 | tee -a ./"log.txt"
 $ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO umount "$solarus_file" || true
-$ESUDO systemctl restart oga_events & 
-printf "\033c" >> /dev/tty1
-printf "\033c" > /dev/tty0
+
+# Cleanup
+pm_finish


### PR DESCRIPTION
The solarus ports were missing `/usr/lib` in their exports which caused them to be broken on rocknix.