### PR TITLE
RLVM Update

### DIFF
--- a/ports/air/Air.sh
+++ b/ports/air/Air.sh
@@ -71,11 +71,16 @@ $ESUDO chmod 666 /dev/tty1
 $ESUDO chmod 666 /dev/uinput
 $GPTOKEYB "$runtime" -c "rlvm.gptk" & 
 
+# Disable touchscreen
+modprobe -r edt_ft5x06
+
 # Run the game
 echo "Loading, please wait... (might take a while!)" > /dev/tty0
+pm_platform_helper "$runtime"
 $runtime $font "$GAMEDIR/gamedata"
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO umount "$rlvm_file" || true
-$ESUDO systemctl restart oga_events & 
-printf "\033c" >> /dev/tty1
-printf "\033c" > /dev/tty0
+
+# Cleanup
+pm_finish
+
+# Re-enable touchscreen
+modprobe edt_ft5x06

--- a/ports/air/Air.sh
+++ b/ports/air/Air.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
@@ -24,7 +23,8 @@ DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 runtime="rlvm"
 rlvm_dir="$HOME/rlvm"
 rlvm_file="$controlfolder/libs/${runtime}.squashfs"
-font="--font $rlvm_dir/fonts/msgothic.ttc"
+font="--font $rlvm_dir/fonts/sazanami-gothic.ttf"
+font2="--font $rlvm_dir/fonts/DejaVuSans.ttf"
 
 cd $GAMEDIR
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
@@ -52,18 +52,18 @@ $ESUDO umount "$rlvm_file" || true
 $ESUDO mount "$rlvm_file" "$rlvm_dir"
 PATH="$rlvm_dir:$PATH"
 
+# Export libs
+export LD_LIBRARY_PATH="$rlvm_dir/libs":$LD_LIBRARY_PATH
+if [ "$LIBGL_FB" != "" ]; then
+  export SDL_VIDEO_GL_DRIVER="$rlvm_dir/gl4es/libGL.so.1"
+  export LD_LIBRARY_PATH="$rlvm_dir/gl4es:$LD_LIBRARY_PATH"
+fi
+
 # Create the config folders
 for SAVEDIR in "${SAVEDIR[@]}"; do
     rm -rf "$HOME/.rlvm/$SAVEDIR"
     ln -s "$GAMEDIR/saves" "$HOME/.rlvm/$SAVEDIR"
 done
-
-export LD_LIBRARY_PATH="$rlvm_dir/libs":$LD_LIBRARY_PATH
-if [ "$LIBGL_FB" != "" ]; then
-  export SDL_VIDEO_GL_DRIVER="$rlvm_dir/gl4es/libGL.so.1"
-  export LD_LIBRARY_PATH="$rlvm_dir/gl4es:$LD_LIBRARY_PATH"
-  export LD_LIBRARY_PATH="$rlvm_dir/gl4es:$LD_LIBRARY_PATH"
-fi
 
 # Setup controls
 $ESUDO chmod 666 /dev/tty0

--- a/ports/clannad/Clannad.sh
+++ b/ports/clannad/Clannad.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
@@ -23,7 +22,8 @@ DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 runtime="rlvm"
 rlvm_dir="$HOME/rlvm"
 rlvm_file="$controlfolder/libs/${runtime}.squashfs"
-font="--font $rlvm_dir/fonts/msgothic.ttc"
+font="--font $rlvm_dir/fonts/sazanami-gothic.ttf"
+font2="--font $rlvm_dir/fonts/DejaVuSans.ttf"
 
 cd $GAMEDIR
 
@@ -56,6 +56,7 @@ PATH="$rlvm_dir:$PATH"
 rm -rf "$HOME/.rlvm/KEY_CLANNAD_ENHD"
 ln -s "$GAMEDIR/saves" "$HOME/.rlvm/KEY_CLANNAD_ENHD"
 
+# Export libs
 export LD_LIBRARY_PATH="$rlvm_dir/libs":$LD_LIBRARY_PATH
 if [ "$LIBGL_FB" != "" ]; then
   export SDL_VIDEO_GL_DRIVER="$rlvm_dir/gl4es/libGL.so.1"

--- a/ports/clannad/Clannad.sh
+++ b/ports/clannad/Clannad.sh
@@ -69,11 +69,16 @@ $ESUDO chmod 666 /dev/tty1
 $ESUDO chmod 666 /dev/uinput
 $GPTOKEYB "$runtime" -c "rlvm.gptk" & 
 
+# Disable touchscreen
+modprobe -r edt_ft5x06
+
 # Run the game
 echo "Loading, please wait... (might take a while!)" > /dev/tty0
+pm_platform_helper "$runtime"
 $runtime $font "$GAMEDIR/gamedata"
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO umount "$rlvm_file" || true
-$ESUDO systemctl restart oga_events & 
-printf "\033c" >> /dev/tty1
-printf "\033c" > /dev/tty0
+
+# Cleanup
+pm_finish
+
+# Re-enable touchscreen
+modprobe edt_ft5x06

--- a/ports/kanon/Kanon.sh
+++ b/ports/kanon/Kanon.sh
@@ -71,11 +71,16 @@ $ESUDO chmod 666 /dev/tty1
 $ESUDO chmod 666 /dev/uinput
 $GPTOKEYB "$runtime" -c "rlvm.gptk" & 
 
+# Disable touchscreen
+modprobe -r edt_ft5x06
+
 # Run the game
 echo "Loading, please wait... (might take a while!)" > /dev/tty0
+pm_platform_helper "$runtime"
 $runtime $font "$GAMEDIR/gamedata"
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO umount "$rlvm_file" || true
-$ESUDO systemctl restart oga_events & 
-printf "\033c" >> /dev/tty1
-printf "\033c" > /dev/tty0
+
+# Cleanup
+pm_finish
+
+# Re-enable touchscreen
+modprobe edt_ft5x06

--- a/ports/kanon/Kanon.sh
+++ b/ports/kanon/Kanon.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
@@ -23,7 +22,8 @@ DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 runtime="rlvm"
 rlvm_dir="$HOME/rlvm"
 rlvm_file="$controlfolder/libs/${runtime}.squashfs"
-font="--font $rlvm_dir/fonts/msgothic.ttc"
+font="--font $rlvm_dir/fonts/sazanami-gothic.ttf"
+font2="--font $rlvm_dir/fonts/DejaVuSans.ttf"
 
 cd $GAMEDIR
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
@@ -58,6 +58,7 @@ for DIR in $SAVEDIRS; do
     ln -s "$GAMEDIR/saves" "$HOME/.rlvm/$DIR"
 done
 
+# Export libs
 export LD_LIBRARY_PATH="$rlvm_dir/libs":$LD_LIBRARY_PATH
 if [ "$LIBGL_FB" != "" ]; then
   export SDL_VIDEO_GL_DRIVER="$rlvm_dir/gl4es/libGL.so.1"

--- a/ports/littlebusters/Little Busters!.sh
+++ b/ports/littlebusters/Little Busters!.sh
@@ -68,11 +68,16 @@ $ESUDO chmod 666 /dev/tty1
 $ESUDO chmod 666 /dev/uinput
 $GPTOKEYB "$runtime" -c "rlvm.gptk" & 
 
+# Disable touchscreen
+modprobe -r edt_ft5x06
+
 # Run the game
 echo "Loading, please wait... (might take a while!)" > /dev/tty0
+pm_platform_helper "$runtime"
 $runtime $font "$GAMEDIR/gamedata"
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO umount "$rlvm_file" || true
-$ESUDO systemctl restart oga_events & 
-printf "\033c" >> /dev/tty1
-printf "\033c" > /dev/tty0
+
+# Cleanup
+pm_finish
+
+# Re-enable touchscreen
+modprobe edt_ft5x06

--- a/ports/littlebusters/Little Busters!.sh
+++ b/ports/littlebusters/Little Busters!.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
@@ -23,7 +22,8 @@ DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 runtime="rlvm"
 rlvm_dir="$HOME/rlvm"
 rlvm_file="$controlfolder/libs/${runtime}.squashfs"
-font="--font $rlvm_dir/fonts/msgothic.ttc"
+font="--font $rlvm_dir/fonts/sazanami-gothic.ttf"
+font2="--font $rlvm_dir/fonts/DejaVuSans.ttf"
 
 cd $GAMEDIR
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
@@ -55,6 +55,7 @@ PATH="$rlvm_dir:$PATH"
 rm -rf "$HOME/.rlvm/KEY_リトルバスターズ！"
 ln -s "$GAMEDIR/saves" "$HOME/.rlvm/KEY_リトルバスターズ！"
 
+# Export libs
 export LD_LIBRARY_PATH="$rlvm_dir/libs":$LD_LIBRARY_PATH
 if [ "$LIBGL_FB" != "" ]; then
   export SDL_VIDEO_GL_DRIVER="$rlvm_dir/gl4es/libGL.so.1"

--- a/ports/planetarian/Planetarian.sh
+++ b/ports/planetarian/Planetarian.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
@@ -23,7 +22,8 @@ DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 runtime="rlvm"
 rlvm_dir="$HOME/rlvm"
 rlvm_file="$controlfolder/libs/${runtime}.squashfs"
-font="--font $rlvm_dir/fonts/msgothic.ttc"
+font="--font $rlvm_dir/fonts/sazanami-gothic.ttf"
+font2="--font $rlvm_dir/fonts/DejaVuSans.ttf"
 
 cd $GAMEDIR
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
@@ -55,6 +55,7 @@ PATH="$rlvm_dir:$PATH"
 rm -rf "$HOME/.rlvm/KEY_planetarian_ME"
 ln -s "$GAMEDIR/saves" "$HOME/.rlvm/KEY_planetarian_ME"
 
+# Export libs
 export LD_LIBRARY_PATH="$rlvm_dir/libs":$LD_LIBRARY_PATH
 if [ "$LIBGL_FB" != "" ]; then
   export SDL_VIDEO_GL_DRIVER="$rlvm_dir/gl4es/libGL.so.1"

--- a/ports/planetarian/Planetarian.sh
+++ b/ports/planetarian/Planetarian.sh
@@ -68,11 +68,16 @@ $ESUDO chmod 666 /dev/tty1
 $ESUDO chmod 666 /dev/uinput
 $GPTOKEYB "$runtime" -c "rlvm.gptk" & 
 
+# Disable touchscreen
+modprobe -r edt_ft5x06
+
 # Run the game
 echo "Loading, please wait... (might take a while!)" > /dev/tty0
-$runtime $font "$GAMEDIR/gamedata" 2>&1 | tee ./"log.txt"
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO umount "$rlvm_file" || true
-$ESUDO systemctl restart oga_events & 
-printf "\033c" >> /dev/tty1
-printf "\033c" > /dev/tty0
+pm_platform_helper "$runtime"
+$runtime $font "$GAMEDIR/gamedata"
+
+# Cleanup
+pm_finish
+
+# Re-enable touchscreen
+modprobe edt_ft5x06

--- a/ports/tomoyo_after/Clannad Tomoyo After.sh
+++ b/ports/tomoyo_after/Clannad Tomoyo After.sh
@@ -79,11 +79,16 @@ $ESUDO chmod 666 /dev/tty1
 $ESUDO chmod 666 /dev/uinput
 $GPTOKEYB "$runtime" -c "rlvm.gptk" & 
 
+# Disable touchscreen
+modprobe -r edt_ft5x06
+
 # Run the game
 echo "Loading, please wait... (might take a while!)" > /dev/tty0
+pm_platform_helper "$runtime"
 $runtime $font "$GAMEDIR/gamedata"
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO umount "$rlvm_file" || true
-$ESUDO systemctl restart oga_events & 
-printf "\033c" >> /dev/tty1
-printf "\033c" > /dev/tty0
+
+# Cleanup
+pm_finish
+
+# Re-enable touchscreen
+modprobe edt_ft5x06

--- a/ports/tomoyo_after/Clannad Tomoyo After.sh
+++ b/ports/tomoyo_after/Clannad Tomoyo After.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
@@ -23,7 +22,8 @@ DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 runtime="rlvm"
 rlvm_dir="$HOME/rlvm"
 rlvm_file="$controlfolder/libs/${runtime}.squashfs"
-font="--font $rlvm_dir/fonts/msgothic.ttc"
+font="--font $rlvm_dir/fonts/sazanami-gothic.ttf"
+font2="--font $rlvm_dir/fonts/DejaVuSans.ttf"
 
 cd $GAMEDIR
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
@@ -66,6 +66,7 @@ if grep -q '#REGNAME = "KEY\智代アフター_EN_ALL"' $INI; then
     sed -i 's/#WAKU.001.000.BACK="s_mw00e_convertible"/#WAKU.001.000.BACK="s_mw00e"/' $INI
 fi
 
+# Export libs
 export LD_LIBRARY_PATH="$rlvm_dir/libs":$LD_LIBRARY_PATH
 if [ "$LIBGL_FB" != "" ]; then
   export SDL_VIDEO_GL_DRIVER="$rlvm_dir/gl4es/libGL.so.1"


### PR DESCRIPTION
- Remove msgothic.ttc font
- Add licenses to squashfs
- Alter port sh files to point to alternative fonts

Tested on rocknix, working.

Runtime:
```
│   rlvm
│
├───fonts
│       DejaVuSans.ttf
│       sazanami-gothic.ttf
│
├───gl4es
│       libGL.so.1
│
├───libs
│       libboost_filesystem.so.1.74.0
│       libboost_iostreams.so.1.74.0
│       libboost_program_options.so.1.74.0
│       libboost_serialization.so.1.74.0
│       libbrotlicommon.so.1
│       libbrotlidec.so.1
│       libfreetype.so.6
│       libGLU.so.1
│       liblzma.so.5
│       libSDL-1.2.so.0
│       libzstd.so.1
│
└───licenses
        dejavu-LICENSE.txt
        gl4es-LICENSE.txt
        rlvm-LICENSE.txt
        sazanami-LICENSE.txt
        sdl12-compat-LICENSE.txt
```