### PR TITLE
Replaced symlinks with bind_directories call for Batocera/Knulli compatibility

### DIFF
--- a/ports/owlboy/Owlboy.sh
+++ b/ports/owlboy/Owlboy.sh
@@ -33,19 +33,17 @@ $ESUDO umount "$monofile" || true
 $ESUDO mount "$monofile" "$monodir"
 
 # Setup savedir and configdir
-$ESUDO rm -rf ~/.local/share/Owlboy
-$ESUDO rm -rf ~/.config/Owlboy
-mkdir -p ~/.config
 
 whichos=$(grep "title=" "/usr/share/plymouth/themes/text.plymouth")
 if [[ $whichos == *"RetroOZ"* ]]; then
   # Fix a problem with savedata
+   $ESUDO rm -rf ~/.local/share/Owlboy
   mkdir -p ~/.local/share/Owlboy
   cp -r "$GAMEDIR/savedata/Saves/" ~/.local/share/Owlboy
 else
-  ln -sfv "$GAMEDIR/savedata" ~/.local/share/Owlboy
+  bind_directories ~/.local/share/Owlboy "$GAMEDIR/savedata"
 fi
-ln -sfv "$GAMEDIR/savedata" ~/.config/Owlboy
+bind_directories ~/.config/Owlboy "$GAMEDIR/savedata"
 
 # Remove all the dependencies in favour of system libs - e.g. the included 
 # newer version of FNA with patcher included

--- a/ports/shadow.warrior/Shadow Warrior.sh
+++ b/ports/shadow.warrior/Shadow Warrior.sh
@@ -19,8 +19,7 @@ get_controls
 GAMEDIR="/$directory/ports/shadow-warrior"
 cd $GAMEDIR
 
-$ESUDO rm -rf ~/.jfsw
-ln -s $GAMEDIR/conf/.jfsw ~/
+bind_directories ~/.jfsw $GAMEDIR/conf/.jfsw
 
 $ESUDO chmod 666 /dev/tty1
 $ESUDO chmod 666 /dev/uinput

--- a/ports/stardewvalley/StardewValley.sh
+++ b/ports/stardewvalley/StardewValley.sh
@@ -34,8 +34,7 @@ $ESUDO umount "$monofile" || true
 $ESUDO mount "$monofile" "$monodir"
 
 # Setup savedir
-$ESUDO rm -rf ~/.config/StardewValley
-ln -sfv "$gamedir/savedata" ~/.config/StardewValley
+bind_directories ~/.config/StardewValley "$gamedir/savedata"
 
 # Setup path and other environment variables
 export MONOGAME_PATCH="$gamedir/dlls/StardewPatches.dll"

--- a/ports/tmntsr/TMNTShreddersRevenge.sh
+++ b/ports/tmntsr/TMNTShreddersRevenge.sh
@@ -35,9 +35,8 @@ $ESUDO umount "$monofile" || true
 $ESUDO mount "$monofile" "$monodir"
 
 # Setup savedir
-$ESUDO rm -rf ~/.local/share/Tribute\ Games/TMNT
-mkdir -p ~/.local/share/Tribute\ Games/
-ln -sfv "$gamedir/savedata" ~/.local/share/Tribute\ Games/TMNT
+bind_directories ~/.local/share/Tribute\ Games/TMNT "$gamedir/savedata"
+
 
 # Remove all the dependencies in favour of system libs - e.g. the included 
 rm -f System*.dll mscorlib.dll FNA.dll Mono.*.dll


### PR DESCRIPTION
I learned that you are working on replacing symlinks with mount binding to resolve the issues with exfat-formatted userdata partitions on Batocera/Knulli. I was curious to learn how it works, so I had a close look to the documentation [here](https://github.com/PortsMaster/PortMaster-GUI/blob/f821da4fd61537a7d95676b3a5872a72eb9c0270/PortMaster/funcs.txt#L39) and checked out some examples from your commit history.

Afterwards, I have adapted the few ports I currently have on my device to use `bind_directories` instead of `ln`:

* TMNT: Shredder's Revenge
* Stardew Valley
* Shadow Warrior
* Owlboy

I tested all 4 games on my Knulli driven handhelds (RG40XXH, RGCubeXX) on ext4- and exfat-formatted SD cards. The games worked fine and were able to save and load game progress and settings.

Feel free to decline if you want to do this yourselves. I just figured, since I had those 4 games adapted for myself, I might aswell share, maybe it'll spare someone a few minutes of work and make some other players happy.

Thanks for your great work!