### PR TITLE
Update StardewValley.sh

### DIFF
--- a/ports/stardewvalley/StardewValley.sh
+++ b/ports/stardewvalley/StardewValley.sh
@@ -9,7 +9,7 @@ elif [ -d "/opt/tools/PortMaster/" ]; then
 elif [ -d "$XDG_DATA_HOME/PortMaster/" ]; then
   controlfolder="$XDG_DATA_HOME/PortMaster"
 else
-  controlfolder="/roms/ports/PortMaster"
+  controlfolder="/roms/tools/PortMaster"
 fi
 
 source $controlfolder/control.txt


### PR DESCRIPTION
On ArkOS, mono-6.12.0.122-aarch64.squashfs is not in /roms/ports/PortMaster, but in /roms/tools/PortMaster. Doing this change to the script allowed what was just going back to the ArkOS menu page to launch into StardewValley.

# Updated script to run Stardew Valley

## Game Information
- **Title**: Stardew Valley
- **URL**: https://portmaster.games/detail.html?name=stardewvalley

## Submission Requirements

### CFW Tests
Ensure your game has been tested on all major CFWs:
- [ ] AmberELEC
- [X] ArkOS
- [ ] ROCKNIX
- [ ] muOS

### Resolution Tests
Test all major resolutions:
- [ ] 480x320
- [X] 640x480
- [ ] 720x720 (RGB30)
- [ ] Higher resolutions (e.g., 1280x720)