### PR TITLE
Runtime: fix wrong naming for the Pyxel runtime

### DIFF
--- a/runtimes/runtimes.json
+++ b/runtimes/runtimes.json
@@ -89,7 +89,7 @@
             "aarch64": "mono-6.12.0.122-aarch64.squashfs"
         }
     },
-    "pyxel_2.2.8_python_3.11": {
+    "pyxel_2.2.8_python_3.11.squashfs": {
         "name": "Pyxel 2.2.8",
         "default": "aarch64",
         "arch": {


### PR DESCRIPTION
I hop it's better this way