### PR TITLE
Shovel Knight: Replace symbolic links with bind mounts.

### DIFF
--- a/ports/shovel.knight/Shovel Knight.sh
+++ b/ports/shovel.knight/Shovel Knight.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 export PORT_32BIT="Y"
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
@@ -56,8 +55,7 @@ export BOX86_LD_LIBRARY_PATH=$GAMEDIR/box86/lib:/usr/lib32/:./:lib/:lib32/:x86/
 export BOX86_DYNAREC=1
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-$ESUDO rm -rf "$XDG_DATA_HOME/Yacht Club Games"
-$ESUDO ln -s "$GAMEDIR/Yacht Club Games" "$XDG_DATA_HOME"
+bind_directories "$XDG_DATA_HOME/Yacht Club Games" "$GAMEDIR/Yacht Club Games"
 $ESUDO chmod 666 /dev/uinput
 
 chmod +x ShovelKnight $GAMEDIR/box86/box86


### PR DESCRIPTION
To enable exFAT support on certain CFWs, We replaced symbolic links with bind mounts using the `bind_directories` function included with PortMaster GUI.

The scope of this task was limited to implementing bind_directories and any fixes preventing the port from launching. Each port was tested in Knulli and one other PM supported CFW (ROCKNIX, most times).

The following criteria were used to validate that a port had passed our testing:
* The port loads without issue, even after rebooting the device.
* The saves/settings persist, even after rebooting the device.
* If port was installed previously, the existing saves/settings were preserved when testing the new version.