### PR TITLE
Chasm: Replace symbolic links with bind mounts.

### DIFF
--- a/ports/chasm/Chasm.sh
+++ b/ports/chasm/Chasm.sh
@@ -14,7 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 gameassembly="Chasm.exe"
@@ -34,8 +34,7 @@ $ESUDO umount "$monofile" || true
 $ESUDO mount "$monofile" "$monodir"
 
 # Setup savedir
-$ESUDO rm -rf ~/.local/share/Chasm
-ln -sfv "$gamedir/savedata" ~/.local/share/Chasm
+bind_directories ~/.local/share/Chasm "$gamedir/savedata"
 
 # Remove all the dependencies in favour of system libs - e.g. the included 
 # newer version of FNA with patcher included
@@ -59,4 +58,5 @@ $ESUDO umount "$monodir"
 
 # Disable console
 printf "\033c" >> /dev/tty1
+
 


### PR DESCRIPTION
To enable exFAT support on certain CFWs, We replaced symbolic links with bind mounts using the `bind_directories` function included with PortMaster GUI.

The scope of this task was limited to implementing bind_directories and any fixes preventing the port from launching. Each port was tested in Knulli and one other PM supported CFW (ROCKNIX, most times).

The following criteria were used to validate that a port had passed our testing:
* The port loads without issue, even after rebooting the device.
* The saves/settings persist, even after rebooting the device.
* If port was installed previously, the existing saves/settings were preserved when testing the new version.