### PR TITLE
Wolfenstein: Replace symbolic links with bind mounts.

### DIFF
--- a/ports/wolf3d/Wolfenstein 3D.sh
+++ b/ports/wolf3d/Wolfenstein 3D.sh
@@ -13,8 +13,8 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
+
 get_controls
 
 # Variables
@@ -26,10 +26,8 @@ cd $GAMEDIR
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
 # Create config dir
-rm -rf "$XDG_DATA_HOME/lzwolf"
-rm -rf "$XDG_DATA_HOME/ecwolf"
-ln -s "$GAMEDIR/cfg" "$XDG_DATA_HOME/lzwolf"
-ln -s "$GAMEDIR/cfg" "$XDG_DATA_HOME/ecwolf"
+bind_directories "$XDG_DATA_HOME/lzwolf" "$GAMEDIR/cfg"
+bind_directories "$XDG_DATA_HOME/ecwolf" "$GAMEDIR/cfg"
 
 # Permissions
 $ESUDO chmod 666 /dev/tty0
@@ -167,3 +165,4 @@ $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty1
 printf "\033c" > /dev/tty0
+


### PR DESCRIPTION
To enable exFAT support on certain CFWs, We replaced symbolic links with bind mounts using the `bind_directories` function included with PortMaster GUI.

The scope of this task was limited to implementing bind_directories and any fixes preventing the port from launching. Each port was tested in Knulli and one other PM supported CFW (ROCKNIX, most times).

The following criteria were used to validate that a port had passed our testing:
* The port loads without issue, even after rebooting the device.
* The saves/settings persist, even after rebooting the device.
* If port was installed previously, the existing saves/settings were preserved when testing the new version.