### PR TITLE
Axiom Verge: Replace symbolic links with bind mounts.

### DIFF
--- a/ports/axiom.verge/Axiom Verge.sh
+++ b/ports/axiom.verge/Axiom Verge.sh
@@ -14,7 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/axiom-verge"
@@ -32,9 +32,7 @@ $ESUDO umount "$monofile" || true
 $ESUDO mount "$monofile" "$monodir"
 
 # Setup savedir
-$ESUDO rm -rf ~/.local/share/AxiomVerge
-mkdir -p ~/.local/share
-ln -sfv "$GAMEDIR/savedata" ~/.local/share/AxiomVerge
+bind_directories ~/.local/share/AxiomVerge "$GAMEDIR/savedata"
 
 # Remove all the dependencies in favour of system libs - e.g. the included 
 # newer version of FNA with patcher included
@@ -67,4 +65,5 @@ unset LD_LIBRARY_PATH
 # Disable console
 printf "\033c" >> /dev/tty1
 printf "\033c" > /dev/tty0
+
 


### PR DESCRIPTION
To enable exFAT support on certain CFWs, We replaced symbolic links with bind mounts using the `bind_directories` function included with PortMaster GUI.

The scope of this task was limited to implementing bind_directories and any fixes preventing the port from launching. Each port was tested in Knulli and one other PM supported CFW (ROCKNIX, most times).

The following criteria were used to validate that a port had passed our testing:
* The port loads without issue, even after rebooting the device.
* The saves/settings persist, even after rebooting the device.
* If port was installed previously, the existing saves/settings were preserved when testing the new version.