### PR TITLE
Meritous: Replace symbolic links with bind mounts.

### DIFF
--- a/ports/meritous/Meritous.sh
+++ b/ports/meritous/Meritous.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -21,8 +22,7 @@ GAMEDIR=/$directory/ports/meritous
 
 cd $GAMEDIR
 
-$ESUDO rm -rf ~/.meritous
-ln -sfv /$directory/ports/meritous/conf/.meritous ~/
+bind_directories ~/.meritous /$directory/ports/meritous/conf/.meritous
 
 export LD_LIBRARY_PATH="$GAMEDIR/libs:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
@@ -35,3 +35,4 @@ $GPTOKEYB "meritous" -c "./meritous.gptk" &
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty0
+


### PR DESCRIPTION
To enable exFAT support on certain CFWs, We replaced symbolic links with bind mounts using the `bind_directories` function included with PortMaster GUI.

The scope of this task was limited to implementing bind_directories and any fixes preventing the port from launching. Each port was tested in Knulli and one other PM supported CFW (ROCKNIX, most times).

The following criteria were used to validate that a port had passed our testing:
* The port loads without issue, even after rebooting the device.
* The saves/settings persist, even after rebooting the device.
* If port was installed previously, the existing saves/settings were preserved when testing the new version.

### Issues Identified
* Scaling Issues on the RGB30 (1:1) running ROCKNIX - [link to issue](https://github.com/PortsMaster/PortMaster-New/issues/1057)