### PR TITLE
Ready to runs: Replace symbolic links with bind mounts.

### DIFF
--- a/ports/armagetronad/Armagetron Advanced.sh
+++ b/ports/armagetronad/Armagetron Advanced.sh
@@ -13,7 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
+source $controlfolder/device_info.txt
 
 get_controls
 
@@ -31,7 +31,8 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export TEXTINPUTINTERACTIVE="Y"
 #export XDG_DATA_HOME="$CONFDIR"
 
-bind_directories ~/.armagetronad /$directory/ports/armagetronad/conf/.armagetronad
+$ESUDO rm -rf ~/.armagetronad
+ln -sfv /$directory/ports/armagetronad/conf/.armagetronad ~/
 
 cd $GAMEDIR
 

--- a/ports/armagetronad/Armagetron Advanced.sh
+++ b/ports/armagetronad/Armagetron Advanced.sh
@@ -13,7 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -31,8 +31,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export TEXTINPUTINTERACTIVE="Y"
 #export XDG_DATA_HOME="$CONFDIR"
 
-$ESUDO rm -rf ~/.armagetronad
-ln -sfv /$directory/ports/armagetronad/conf/.armagetronad ~/
+bind_directories ~/.armagetronad /$directory/ports/armagetronad/conf/.armagetronad
 
 cd $GAMEDIR
 

--- a/ports/asylum/Asylum.sh
+++ b/ports/asylum/Asylum.sh
@@ -12,6 +12,8 @@ else
 fi
 
 source $controlfolder/control.txt
+source $controlfolder/device_info.txt
+
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -33,7 +35,8 @@ export XDG_DATA_HOME="$CONFDIR"
 
 $ESUDO chmod 666 /dev/uinput
 
-bind_files ~/.asylum /$directory/ports/asylum/conf/.asylum
+$ESUDO rm -rf ~/.asylum
+ln -sfv /$directory/ports/asylum/conf/.asylum ~/
 
 cd $GAMEDIR
 

--- a/ports/asylum/Asylum.sh
+++ b/ports/asylum/Asylum.sh
@@ -12,8 +12,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -35,8 +33,7 @@ export XDG_DATA_HOME="$CONFDIR"
 
 $ESUDO chmod 666 /dev/uinput
 
-$ESUDO rm -rf ~/.asylum
-ln -sfv /$directory/ports/asylum/conf/.asylum ~/
+bind_files ~/.asylum /$directory/ports/asylum/conf/.asylum
 
 cd $GAMEDIR
 

--- a/ports/asylum/Asylum.sh
+++ b/ports/asylum/Asylum.sh
@@ -33,7 +33,10 @@ export XDG_DATA_HOME="$CONFDIR"
 
 $ESUDO chmod 666 /dev/uinput
 
-bind_files ~/.asylum /$directory/ports/asylum/conf/.asylum
+# We need to wait until bind_files comes out of beta, for now it will remain the same.
+$ESUDO rm -rf ~/.asylum
+ln -sfv /$directory/ports/asylum/conf/.asylum ~/
+# bind_files ~/.asylum /$directory/ports/asylum/conf/.asylum
 
 cd $GAMEDIR
 

--- a/ports/asylum/Asylum.sh
+++ b/ports/asylum/Asylum.sh
@@ -35,7 +35,6 @@ export XDG_DATA_HOME="$CONFDIR"
 $ESUDO chmod 666 /dev/uinput
 
 # delete the remenents of the old file structure
-$ESUDO rm -rf ~/.asylum/*
 bind_directories: ~/.asylum "$GAMEDIR/conf/.asylum"
 
 cd $GAMEDIR

--- a/ports/asylum/Asylum.sh
+++ b/ports/asylum/Asylum.sh
@@ -12,6 +12,7 @@ else
 fi
 
 source $controlfolder/control.txt
+
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -33,10 +34,9 @@ export XDG_DATA_HOME="$CONFDIR"
 
 $ESUDO chmod 666 /dev/uinput
 
-# We need to wait until bind_files comes out of beta, for now it will remain the same.
-$ESUDO rm -rf ~/.asylum
-ln -sfv /$directory/ports/asylum/conf/.asylum ~/
-# bind_files ~/.asylum /$directory/ports/asylum/conf/.asylum
+# delete the remenents of the old file structure
+$ESUDO rm -rf ~/.asylum/*
+bind_directories: ~/.asylum "$GAMEDIR/conf/.asylum"
 
 cd $GAMEDIR
 

--- a/ports/block.attack/Block Attack.sh
+++ b/ports/block.attack/Block Attack.sh
@@ -13,7 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
+source $controlfolder/device_info.txt
 
 get_controls
 
@@ -21,7 +21,8 @@ GAMEDIR="/$directory/ports/blockattack"
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 cd $GAMEDIR
 
-bind_directories ~/.local/share/blockattack $GAMEDIR/
+$ESUDO rm -rf ~/.local/share/blockattack
+ln -sfv $GAMEDIR/ ~/.local/share
 
 DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 
@@ -36,4 +37,3 @@ $GPTOKEYB "blockattack.${DEVICE_ARCH}" -c "$GAMEDIR/blockattack.gptk" &
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty1
-

--- a/ports/block.attack/Block Attack.sh
+++ b/ports/block.attack/Block Attack.sh
@@ -13,7 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -21,8 +21,7 @@ GAMEDIR="/$directory/ports/blockattack"
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 cd $GAMEDIR
 
-$ESUDO rm -rf ~/.local/share/blockattack
-ln -sfv $GAMEDIR/ ~/.local/share
+bind_directories ~/.local/share/blockattack $GAMEDIR/
 
 DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 
@@ -37,3 +36,4 @@ $GPTOKEYB "blockattack.${DEVICE_ARCH}" -c "$GAMEDIR/blockattack.gptk" &
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty1
+

--- a/ports/boswars/Bos Wars.sh
+++ b/ports/boswars/Bos Wars.sh
@@ -12,6 +12,8 @@ else
 fi
 
 source $controlfolder/control.txt
+source $controlfolder/device_info.txt
+
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -28,7 +30,8 @@ export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export XDG_DATA_HOME="$CONFDIR"
 
-bind_directories ~/.boswars $GAMEDIR/conf/.boswars
+$ESUDO rm -rf ~/.boswars
+ln -sfv $GAMEDIR/conf/.boswars ~/
 
 sed -i "s/\(VideoWidth = \)[0-9]\+\(,\)/\1$DISPLAY_WIDTH\2/" $GAMEDIR/conf/.boswars/preferences.lua
 sed -i "s/\(VideoHeight = \)[0-9]\+\(,\)/\1$DISPLAY_HEIGHT\2/" $GAMEDIR/conf/.boswars/preferences.lua

--- a/ports/boswars/Bos Wars.sh
+++ b/ports/boswars/Bos Wars.sh
@@ -12,8 +12,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -30,8 +28,7 @@ export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export XDG_DATA_HOME="$CONFDIR"
 
-$ESUDO rm -rf ~/.boswars
-ln -sfv $GAMEDIR/conf/.boswars ~/
+bind_directories ~/.boswars $GAMEDIR/conf/.boswars
 
 sed -i "s/\(VideoWidth = \)[0-9]\+\(,\)/\1$DISPLAY_WIDTH\2/" $GAMEDIR/conf/.boswars/preferences.lua
 sed -i "s/\(VideoHeight = \)[0-9]\+\(,\)/\1$DISPLAY_HEIGHT\2/" $GAMEDIR/conf/.boswars/preferences.lua

--- a/ports/c-dogs/C-Dogs.sh
+++ b/ports/c-dogs/C-Dogs.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -43,7 +42,8 @@ fi
 
 
 
-bind_directories ~/.config/cdogs-sdl $GAMEDIR/conf/cdogs-sdl/
+rm -rf ~/.config/cdogs-sdl
+ln -sfv $GAMEDIR/conf/cdogs-sdl/ ~/.config/
 
 cd $GAMEDIR/data
 
@@ -53,5 +53,4 @@ $ESUDO $controlfolder/oga_controls cdogs-sdl $param_device &
 $ESUDO kill -9 $(pidof oga_controls)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty1
-
 

--- a/ports/c-dogs/C-Dogs.sh
+++ b/ports/c-dogs/C-Dogs.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -42,8 +43,7 @@ fi
 
 
 
-rm -rf ~/.config/cdogs-sdl
-ln -sfv $GAMEDIR/conf/cdogs-sdl/ ~/.config/
+bind_directories ~/.config/cdogs-sdl $GAMEDIR/conf/cdogs-sdl/
 
 cd $GAMEDIR/data
 
@@ -53,4 +53,5 @@ $ESUDO $controlfolder/oga_controls cdogs-sdl $param_device &
 $ESUDO kill -9 $(pidof oga_controls)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty1
+
 

--- a/ports/ceferino/Don Ceferino Hazaña.sh
+++ b/ports/ceferino/Don Ceferino Hazaña.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -31,8 +30,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export XDG_DATA_HOME="$CONFDIR"
 export TEXTINPUTINTERACTIVE="Y" 
 
-$ESUDO rm -rf ~/.ceferino
-ln -sfv $GAMEDIR/conf/.ceferino ~/
+bind_files ~/.ceferino $GAMEDIR/conf/.ceferino
 
 cd $GAMEDIR
 

--- a/ports/ceferino/Don Ceferino Hazaña.sh
+++ b/ports/ceferino/Don Ceferino Hazaña.sh
@@ -30,7 +30,10 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export XDG_DATA_HOME="$CONFDIR"
 export TEXTINPUTINTERACTIVE="Y" 
 
-bind_files ~/.ceferino $GAMEDIR/conf/.ceferino
+# Must wait until bind_files comes out of beta
+$ESUDO rm -rf ~/.ceferino
+ln -sfv $GAMEDIR/conf/.ceferino ~/
+# bind_files ~/.ceferino $GAMEDIR/conf/.ceferino
 
 cd $GAMEDIR
 

--- a/ports/ceferino/Don Ceferino Hazaña.sh
+++ b/ports/ceferino/Don Ceferino Hazaña.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -23,19 +24,14 @@ BINARY=ceferino
 
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
-mkdir -p "$GAMEDIR/conf"
+cd $GAMEDIR
+
+bind_files ~/.ceferino $GAMEDIR/conf/.ceferino
 
 export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export XDG_DATA_HOME="$CONFDIR"
 export TEXTINPUTINTERACTIVE="Y" 
-
-# Must wait until bind_files comes out of beta
-$ESUDO rm -rf ~/.ceferino
-ln -sfv $GAMEDIR/conf/.ceferino ~/
-# bind_files ~/.ceferino $GAMEDIR/conf/.ceferino
-
-cd $GAMEDIR
 
 $GPTOKEYB "$BINARY" -c ./$BINARY.gptk &
 pm_platform_helper "$GAMEDIR/$BINARY"

--- a/ports/ceferino/Don Ceferino Hazaña.sh
+++ b/ports/ceferino/Don Ceferino Hazaña.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -30,7 +31,8 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export XDG_DATA_HOME="$CONFDIR"
 export TEXTINPUTINTERACTIVE="Y" 
 
-bind_files ~/.ceferino $GAMEDIR/conf/.ceferino
+$ESUDO rm -rf ~/.ceferino
+ln -sfv $GAMEDIR/conf/.ceferino ~/
 
 cd $GAMEDIR
 

--- a/ports/freesiege/FreeSiege.sh
+++ b/ports/freesiege/FreeSiege.sh
@@ -12,6 +12,8 @@ else
 fi
 
 source $controlfolder/control.txt
+source $controlfolder/device_info.txt
+
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -31,7 +33,8 @@ export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 #export TEXTINPUTINTERACTIVE="Y"
 
-bind_directories ~/.freesiege /$directory/ports/freesiege/conf/.freesiege
+$ESUDO rm -rf ~/.freesiege
+ln -sfv /$directory/ports/freesiege/conf/.freesiege ~/
 
 cd $GAMEDIR
 

--- a/ports/freesiege/FreeSiege.sh
+++ b/ports/freesiege/FreeSiege.sh
@@ -12,8 +12,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -33,8 +31,7 @@ export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 #export TEXTINPUTINTERACTIVE="Y"
 
-$ESUDO rm -rf ~/.freesiege
-ln -sfv /$directory/ports/freesiege/conf/.freesiege ~/
+bind_directories ~/.freesiege /$directory/ports/freesiege/conf/.freesiege
 
 cd $GAMEDIR
 

--- a/ports/gigalomania/Gigalomania.sh
+++ b/ports/gigalomania/Gigalomania.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -21,8 +22,7 @@ GAMEDIR=/$directory/ports/gigalomania
 
 cd $GAMEDIR
 
-$ESUDO rm -rf ~/.config/gigalomania/
-ln -sfv /$directory/ports/gigalomania/conf/ ~/.config/gigalomania
+bind_directories ~/.config/gigalomania/ /$directory/ports/gigalomania/conf/
 
 export LD_LIBRARY_PATH="$PWD/libs:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
@@ -35,3 +35,4 @@ $GPTOKEYB "gigalomania" -c "./gigalomania.gptk" &
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty0
+

--- a/ports/gigalomania/Gigalomania.sh
+++ b/ports/gigalomania/Gigalomania.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -22,7 +21,8 @@ GAMEDIR=/$directory/ports/gigalomania
 
 cd $GAMEDIR
 
-bind_directories ~/.config/gigalomania/ /$directory/ports/gigalomania/conf/
+$ESUDO rm -rf ~/.config/gigalomania/
+ln -sfv /$directory/ports/gigalomania/conf/ ~/.config/gigalomania
 
 export LD_LIBRARY_PATH="$PWD/libs:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
@@ -35,4 +35,3 @@ $GPTOKEYB "gigalomania" -c "./gigalomania.gptk" &
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty0
-

--- a/ports/grafx2/Grafx2.sh
+++ b/ports/grafx2/Grafx2.sh
@@ -12,6 +12,8 @@ else
 fi
 
 source $controlfolder/control.txt
+source $controlfolder/device_info.txt
+
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -25,7 +27,8 @@ mkdir -p "$GAMEDIR/conf"
 
 $ESUDO chmod 666 /dev/uinput
 
-bind_directories ~/.config/grafx2 $GAMEDIR/conf/.config/grafx2
+$ESUDO rm -rf ~/.config/grafx2
+ln -sfv $GAMEDIR/conf/.config/grafx2 ~/.config/
 
 export XDG_DATA_HOME="$CONFDIR"
 export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"

--- a/ports/grafx2/Grafx2.sh
+++ b/ports/grafx2/Grafx2.sh
@@ -12,8 +12,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -27,8 +25,7 @@ mkdir -p "$GAMEDIR/conf"
 
 $ESUDO chmod 666 /dev/uinput
 
-$ESUDO rm -rf ~/.config/grafx2
-ln -sfv $GAMEDIR/conf/.config/grafx2 ~/.config/
+bind_directories ~/.config/grafx2 $GAMEDIR/conf/.config/grafx2
 
 export XDG_DATA_HOME="$CONFDIR"
 export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"

--- a/ports/heroes/Heroes.sh
+++ b/ports/heroes/Heroes.sh
@@ -12,8 +12,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -30,8 +28,7 @@ export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export XDG_DATA_HOME="$CONFDIR"
 
-$ESUDO rm -rf ~/.heroes
-ln -sfv $GAMEDIR/conf/.heroes ~/
+bind_directories ~/.heroes $GAMEDIR/conf/.heroes
 
 cd $GAMEDIR
 

--- a/ports/heroes/Heroes.sh
+++ b/ports/heroes/Heroes.sh
@@ -12,6 +12,8 @@ else
 fi
 
 source $controlfolder/control.txt
+source $controlfolder/device_info.txt
+
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -28,7 +30,8 @@ export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export XDG_DATA_HOME="$CONFDIR"
 
-bind_directories ~/.heroes $GAMEDIR/conf/.heroes
+$ESUDO rm -rf ~/.heroes
+ln -sfv $GAMEDIR/conf/.heroes ~/
 
 cd $GAMEDIR
 

--- a/ports/hex-a-hop/Hex-A-Hop.sh
+++ b/ports/hex-a-hop/Hex-A-Hop.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -20,8 +21,7 @@ GAMEDIR=/$directory/ports/hex-a-hop
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 cd $GAMEDIR
 
-$ESUDO rm -rf ~/.hex-a-hop
-ln -sfv /$directory/ports/hex-a-hop/conf/.hex-a-hop ~/
+bind_directories ~/.hex-a-hop /$directory/ports/hex-a-hop/conf/.hex-a-hop
 
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export LD_LIBRARY_PATH="$GAMEDIR/libs:$LD_LIBRARY_PATH"
@@ -34,3 +34,4 @@ $GPTOKEYB "hex-a-hop"  -c "./hex-a-hop.gptk" &
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty0
+

--- a/ports/hex-a-hop/Hex-A-Hop.sh
+++ b/ports/hex-a-hop/Hex-A-Hop.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -21,7 +20,8 @@ GAMEDIR=/$directory/ports/hex-a-hop
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 cd $GAMEDIR
 
-bind_directories ~/.hex-a-hop /$directory/ports/hex-a-hop/conf/.hex-a-hop
+$ESUDO rm -rf ~/.hex-a-hop
+ln -sfv /$directory/ports/hex-a-hop/conf/.hex-a-hop ~/
 
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export LD_LIBRARY_PATH="$GAMEDIR/libs:$LD_LIBRARY_PATH"
@@ -34,4 +34,3 @@ $GPTOKEYB "hex-a-hop"  -c "./hex-a-hop.gptk" &
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty0
-

--- a/ports/holotzcastle/Holotz Castle.sh
+++ b/ports/holotzcastle/Holotz Castle.sh
@@ -13,8 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -31,8 +29,7 @@ export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export XDG_DATA_HOME="$CONFDIR"
 
-$ESUDO rm -rf ~/.holotz-castle
-ln -sfv $GAMEDIR/conf/.holotz-castle ~/
+bind_directories ~/.holotz-castle $GAMEDIR/conf/.holotz-castle
 
 cd $GAMEDIR
 

--- a/ports/holotzcastle/Holotz Castle.sh
+++ b/ports/holotzcastle/Holotz Castle.sh
@@ -13,6 +13,8 @@ else
 fi
 
 source $controlfolder/control.txt
+source $controlfolder/device_info.txt
+
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -29,7 +31,8 @@ export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export XDG_DATA_HOME="$CONFDIR"
 
-bind_directories ~/.holotz-castle $GAMEDIR/conf/.holotz-castle
+$ESUDO rm -rf ~/.holotz-castle
+ln -sfv $GAMEDIR/conf/.holotz-castle ~/
 
 cd $GAMEDIR
 

--- a/ports/lierolibre/LieroLibre.sh
+++ b/ports/lierolibre/LieroLibre.sh
@@ -13,15 +13,14 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
 GAMEDIR=/$directory/ports/lierolibre
 
 # Set up savedata
-$ESUDO rm -rf ~/.lierolibre
-ln -sfv "$GAMEDIR/savedata/.lierolibre" ~/
+bind_directories ~/.lierolibre "$GAMEDIR/savedata/.lierolibre"
 
 # Enable logging
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
@@ -41,3 +40,4 @@ $GPTOKEYB "lierolibre" -c "./lierolibre.gptk" &
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty0
+

--- a/ports/lierolibre/LieroLibre.sh
+++ b/ports/lierolibre/LieroLibre.sh
@@ -13,14 +13,15 @@ else
 fi
 
 source $controlfolder/control.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
+source $controlfolder/device_info.txt
 
 get_controls
 
 GAMEDIR=/$directory/ports/lierolibre
 
 # Set up savedata
-bind_directories ~/.lierolibre "$GAMEDIR/savedata/.lierolibre"
+$ESUDO rm -rf ~/.lierolibre
+ln -sfv "$GAMEDIR/savedata/.lierolibre" ~/
 
 # Enable logging
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
@@ -40,4 +41,3 @@ $GPTOKEYB "lierolibre" -c "./lierolibre.gptk" &
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty0
-

--- a/ports/opentyrian/OpenTyrian.sh
+++ b/ports/opentyrian/OpenTyrian.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -31,8 +32,8 @@ elif [[ $whichos == *"RetroOZ"* ]]; then
   cp /home/odroid/.asoundrcfords /home/odroid/.asoundrc
 fi
 
-$ESUDO rm -rf ~/.config/opentyrian
-ln -sfv $GAMEDIR/ ~/.config/
+bind_directories ~/.config/opentyrian $GAMEDIR/
+
 cd $GAMEDIR
 $GPTOKEYB opentyrian &
 $GAMEDIR/opentyrian --data=$GAMEDIR/data 2>&1 | tee $GAMEDIR/log.txt
@@ -46,4 +47,5 @@ fi
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" >> /dev/tty1
+
 

--- a/ports/opentyrian/OpenTyrian.sh
+++ b/ports/opentyrian/OpenTyrian.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -32,8 +31,8 @@ elif [[ $whichos == *"RetroOZ"* ]]; then
   cp /home/odroid/.asoundrcfords /home/odroid/.asoundrc
 fi
 
-bind_directories ~/.config/opentyrian $GAMEDIR/
-
+$ESUDO rm -rf ~/.config/opentyrian
+ln -sfv $GAMEDIR/ ~/.config/
 cd $GAMEDIR
 $GPTOKEYB opentyrian &
 $GAMEDIR/opentyrian --data=$GAMEDIR/data 2>&1 | tee $GAMEDIR/log.txt
@@ -47,5 +46,4 @@ fi
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" >> /dev/tty1
-
 

--- a/ports/rocksndiamonds/Rocks n Diamonds.sh
+++ b/ports/rocksndiamonds/Rocks n Diamonds.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -21,12 +20,12 @@ GAMEDIR="/$directory/ports/rocksndiamonds"
 
 $ESUDO chmod 666 /dev/tty1
 
-bind_directories ~/.rocksndiamonds $GAMEDIR/conf/.rocksndiamonds/
+$ESUDO rm -rf ~/.rocksndiamonds
+ln -sfv $GAMEDIR/conf/.rocksndiamonds/ ~/
 cd $GAMEDIR
 $ESUDO $controlfolder/oga_controls rocksndiamonds $param_device &
 ./rocksndiamonds 2>&1 | tee $GAMEDIR/log.txt
 $ESUDO kill -9 $(pidof oga_controls)
 $ESUDO systemctl restart oga_events &
 printf "\033c" >> /dev/tty1
-
 

--- a/ports/rocksndiamonds/Rocks n Diamonds.sh
+++ b/ports/rocksndiamonds/Rocks n Diamonds.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -20,12 +21,12 @@ GAMEDIR="/$directory/ports/rocksndiamonds"
 
 $ESUDO chmod 666 /dev/tty1
 
-$ESUDO rm -rf ~/.rocksndiamonds
-ln -sfv $GAMEDIR/conf/.rocksndiamonds/ ~/
+bind_directories ~/.rocksndiamonds $GAMEDIR/conf/.rocksndiamonds/
 cd $GAMEDIR
 $ESUDO $controlfolder/oga_controls rocksndiamonds $param_device &
 ./rocksndiamonds 2>&1 | tee $GAMEDIR/log.txt
 $ESUDO kill -9 $(pidof oga_controls)
 $ESUDO systemctl restart oga_events &
 printf "\033c" >> /dev/tty1
+
 

--- a/ports/shippy/Shippy.sh
+++ b/ports/shippy/Shippy.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -21,7 +20,8 @@ GAMEDIR=/$directory/ports/shippy
 
 exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
-bind_directories /storage/.local/share/shippy /$directory/ports/shippy
+$ESUDO rm -rf /storage/.local/share/shippy
+ln -sfv /$directory/ports/shippy /storage/.local/share/shippy
 
 
 cd $GAMEDIR
@@ -33,4 +33,3 @@ SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig" ./shippy
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty0
-

--- a/ports/shippy/Shippy.sh
+++ b/ports/shippy/Shippy.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -20,8 +21,7 @@ GAMEDIR=/$directory/ports/shippy
 
 exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
-$ESUDO rm -rf /storage/.local/share/shippy
-ln -sfv /$directory/ports/shippy /storage/.local/share/shippy
+bind_directories /storage/.local/share/shippy /$directory/ports/shippy
 
 
 cd $GAMEDIR
@@ -33,3 +33,4 @@ SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig" ./shippy
 $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty0
+

--- a/ports/supertransball2/Super Transball 2.sh
+++ b/ports/supertransball2/Super Transball 2.sh
@@ -13,6 +13,8 @@ else
 fi
 
 source $controlfolder/control.txt
+source $controlfolder/device_info.txt
+
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -31,7 +33,8 @@ export XDG_DATA_HOME="$CONFDIR"
 export SUPERTRANSBALL2_CONFIG_DIR=$GAMEDIR/data/
 export SUPERTRANSBALL2_DATA_DIR=$GAMEDIR/data/
 
-bind_directories ~/.supertransball2 $GAMEDIR/conf/.supertransball2
+$ESUDO rm -rf ~/.supertransball2
+ln -sfv $GAMEDIR/conf/.supertransball2 ~/
 
 cd $GAMEDIR
 

--- a/ports/supertransball2/Super Transball 2.sh
+++ b/ports/supertransball2/Super Transball 2.sh
@@ -13,8 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -33,8 +31,7 @@ export XDG_DATA_HOME="$CONFDIR"
 export SUPERTRANSBALL2_CONFIG_DIR=$GAMEDIR/data/
 export SUPERTRANSBALL2_DATA_DIR=$GAMEDIR/data/
 
-$ESUDO rm -rf ~/.supertransball2
-ln -sfv $GAMEDIR/conf/.supertransball2 ~/
+bind_directories ~/.supertransball2 $GAMEDIR/conf/.supertransball2
 
 cd $GAMEDIR
 

--- a/ports/vvvvvv/VVVVVV.sh
+++ b/ports/vvvvvv/VVVVVV.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -20,10 +21,10 @@ GAMEDIR="/$directory/ports/VVVVVV"
 cd $GAMEDIR
 
 $ESUDO chmod 666 /dev/tty1
-$ESUDO rm -rf ~/.local/share/VVVVVV
-ln -s $GAMEDIR ~/.local/share/
+bind_directories ~/.local/share/VVVVVV $GAMEDIR
 $ESUDO $controlfolder/oga_controls VVVVVV $param_device &
 SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig" ./VVVVVV 2>&1 | tee $GAMEDIR/log.txt
 $ESUDO kill -9 $(pidof oga_controls)
 $ESUDO systemctl restart oga_events &
 printf "\033c" >> /dev/tty1
+

--- a/ports/vvvvvv/VVVVVV.sh
+++ b/ports/vvvvvv/VVVVVV.sh
@@ -13,7 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -21,10 +20,10 @@ GAMEDIR="/$directory/ports/VVVVVV"
 cd $GAMEDIR
 
 $ESUDO chmod 666 /dev/tty1
-bind_directories ~/.local/share/VVVVVV $GAMEDIR
+$ESUDO rm -rf ~/.local/share/VVVVVV
+ln -s $GAMEDIR ~/.local/share/
 $ESUDO $controlfolder/oga_controls VVVVVV $param_device &
 SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig" ./VVVVVV 2>&1 | tee $GAMEDIR/log.txt
 $ESUDO kill -9 $(pidof oga_controls)
 $ESUDO systemctl restart oga_events &
 printf "\033c" >> /dev/tty1
-

--- a/ports/wolf3d/Wolfenstein 3D.sh
+++ b/ports/wolf3d/Wolfenstein 3D.sh
@@ -13,8 +13,8 @@ else
 fi
 
 source $controlfolder/control.txt
+source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
-
 get_controls
 
 # Variables
@@ -26,8 +26,10 @@ cd $GAMEDIR
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
 # Create config dir
-bind_directories "$XDG_DATA_HOME/lzwolf" "$GAMEDIR/cfg"
-bind_directories "$XDG_DATA_HOME/ecwolf" "$GAMEDIR/cfg"
+rm -rf "$XDG_DATA_HOME/lzwolf"
+rm -rf "$XDG_DATA_HOME/ecwolf"
+ln -s "$GAMEDIR/cfg" "$XDG_DATA_HOME/lzwolf"
+ln -s "$GAMEDIR/cfg" "$XDG_DATA_HOME/ecwolf"
 
 # Permissions
 $ESUDO chmod 666 /dev/tty0
@@ -165,4 +167,3 @@ $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty1
 printf "\033c" > /dev/tty0
-

--- a/ports/wolf3d/Wolfenstein 3D.sh
+++ b/ports/wolf3d/Wolfenstein 3D.sh
@@ -13,8 +13,8 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
+
 get_controls
 
 # Variables
@@ -26,10 +26,8 @@ cd $GAMEDIR
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
 # Create config dir
-rm -rf "$XDG_DATA_HOME/lzwolf"
-rm -rf "$XDG_DATA_HOME/ecwolf"
-ln -s "$GAMEDIR/cfg" "$XDG_DATA_HOME/lzwolf"
-ln -s "$GAMEDIR/cfg" "$XDG_DATA_HOME/ecwolf"
+bind_directories "$XDG_DATA_HOME/lzwolf" "$GAMEDIR/cfg"
+bind_directories "$XDG_DATA_HOME/ecwolf" "$GAMEDIR/cfg"
 
 # Permissions
 $ESUDO chmod 666 /dev/tty0
@@ -167,3 +165,4 @@ $ESUDO kill -9 $(pidof gptokeyb)
 $ESUDO systemctl restart oga_events &
 printf "\033c" > /dev/tty1
 printf "\033c" > /dev/tty0
+


### PR DESCRIPTION
To enable exFAT support on certain CFWs, We replaced symbolic links with bind mounts using the `bind_directories` function included with PortMaster GUI.

The scope of this task was limited to implementing bind_directories and any fixes preventing the port from launching. Each port was tested in Knulli and one other PM supported CFW (ROCKNIX, most times).

The following criteria were used to validate that a port had passed our testing:
* The port loads without issue, even after rebooting the device.
* The saves/settings persist, even after rebooting the device.
* If port was installed previously, the existing saves/settings were preserved when testing the new version.