### PR TITLE
Golden Hornet - launch script fix

### DIFF
--- a/ports/goldenhornet/Golden Hornet.sh
+++ b/ports/goldenhornet/Golden Hornet.sh
@@ -23,7 +23,7 @@ $ESUDO chmod 666 /dev/tty0
 
 GAMEDIR="/$directory/ports/goldenhornet"
 
-export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/libs":$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/libs:$LD_LIBRARY_PATH"
 export GMLOADER_DEPTH_DISABLE=1
 export GMLOADER_SAVEDIR="$GAMEDIR/gamedata/"
 export GMLOADER_PLATFORM="os_linux"


### PR DESCRIPTION
Fixing a typo that breaks the port. It would benefit from a proper port update later, but at least it works again with this. 
