### PR TITLE
Fix issue with Owlboy launch script

### DIFF
--- a/ports/owlboy/Owlboy.sh
+++ b/ports/owlboy/Owlboy.sh
@@ -27,7 +27,7 @@ echo "Loading... Please Wait." > /dev/tty0
 
 # Setup mono
 monodir="$HOME/mono"
-monofile="/$controlfolder/libs/mono-6.12.0.122-aarch64.squashfs"
+monofile="$controlfolder/libs/mono-6.12.0.122-aarch64.squashfs"
 $ESUDO mkdir -p "$monodir"
 $ESUDO umount "$monofile" || true
 $ESUDO mount "$monofile" "$monodir"
@@ -37,7 +37,7 @@ $ESUDO mount "$monofile" "$monodir"
 whichos=$(grep "title=" "/usr/share/plymouth/themes/text.plymouth")
 if [[ $whichos == *"RetroOZ"* ]]; then
   # Fix a problem with savedata
-   $ESUDO rm -rf ~/.local/share/Owlboy
+  $ESUDO rm -rf ~/.local/share/Owlboy
   mkdir -p ~/.local/share/Owlboy
   cp -r "$GAMEDIR/savedata/Saves/" ~/.local/share/Owlboy
 else
@@ -45,7 +45,7 @@ else
 fi
 bind_directories ~/.config/Owlboy "$GAMEDIR/savedata"
 
-# Remove all the dependencies in favour of system libs - e.g. the included 
+# Remove all the dependencies in favour of system libs - e.g. the included
 # newer version of FNA with patcher included
 rm -f System*.dll mscorlib.dll FNA.dll Mono*.dll
 
@@ -78,4 +78,3 @@ fi
 # Disable console
 printf "\033c" >> /dev/tty1
 printf "\033c" >> /dev/tty0
-


### PR DESCRIPTION
There is an issue in the Owlboy launch script where the `monofile` has been prefixed with a `/` when it should not be. This causes Owlboy to fail to launch as mono cannot be found. This PR fixes this issue, and allow Owlboy to launch

An example of where this has been done correctly can be seen in TNMT: Shredders Revenge

https://github.com/PortsMaster/PortMaster-New/blob/main/ports/tmntsr/TMNTShreddersRevenge.sh#L31-L35

White space changes were made by my shell formatter - but I left them as they seemed reasonable. Happy to revert them if wanted
