### PR TITLE
Fix downwell keybindings

### DIFF
--- a/ports/downwell/downwell/downwell.gptk
+++ b/ports/downwell/downwell/downwell.gptk
@@ -6,15 +6,15 @@ down = \"
 left = \"
 right = \"
 
-left_analog_up = \"
-left_analog_down = \"
-left_analog_left = \"
-left_analog_right = \"
+left_analog_up = up
+left_analog_down = down
+left_analog_left = left
+left_analog_right = right
 
-right_analog_up = right
-right_analog_down = left
-right_analog_left = up
-right_analog_right = down
+right_analog_up = \"
+right_analog_down = \"
+right_analog_left = \"
+right_analog_right = \"
 
 l1 = \"
 l2 = \"
@@ -24,7 +24,7 @@ r1 = \"
 r2 = \"
 r3 = \"
 
-a = \"
-b = \"
+a = space
+b = space
 x = space
 y = space


### PR DESCRIPTION
As mentioned in  #573 the key bindings for Downwell are very odd.

Firstly, the right stick does the moving, when the left stick should do it. Secondly, you have to press up and down on the right stick to move left and right. This PR fixes these issues, updating Downwell to use sensible key bindings.

I have also updated every button to be mapped to space, so a player can choose whichever button they prefer to play.
