### PR TITLE
Blood: Correct library path

### DIFF
--- a/ports/blood/Blood.sh
+++ b/ports/blood/Blood.sh
@@ -16,8 +16,8 @@ source $controlfolder/control.txt
 
 get_controls
 
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/storage/roms/ports/Blood/lib:/usr/lib"
 GAMEDIR="/$directory/ports/Blood"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$GAMEDIR/lib:/usr/lib"
 
 GPTOKEYB_CONFIG="$GAMEDIR/nblood.gptk"
 

--- a/ports/blood/Blood.sh
+++ b/ports/blood/Blood.sh
@@ -17,7 +17,7 @@ source $controlfolder/control.txt
 get_controls
 
 GAMEDIR="/$directory/ports/Blood"
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$GAMEDIR/lib:/usr/lib"
+export LD_LIBRARY_PATH="$GAMEDIR/lib:/usr/lib:$LD_LIBRARY_PATH"
 
 GPTOKEYB_CONFIG="$GAMEDIR/nblood.gptk"
 


### PR DESCRIPTION
Blood.sh has a hard-coded path in LD_LIBRARY path that doesn't point to the intended folder on all platforms. This should be relative to $GAMEDIR instead.