### PR TITLE
fix to_lower_case() to work correctly on vfat partitions

### DIFF
--- a/ports/avp/Alien vs Predator.sh
+++ b/ports/avp/Alien vs Predator.sh
@@ -26,10 +26,13 @@ cd $GAMEDIR
 
 to_lower_case() {
     for SRC in $(find "$1" -depth); do
-    DST=$(dirname "${SRC}")/$(basename "${SRC}" | tr '[A-Z]' '[a-z]')
-    if [ "${SRC}" != "${DST}" ]; then
-        [ ! -e "${DST}" ] && $ESUDO mv -vT "${SRC}" "${DST}" || echo "- ${SRC} was not renamed"
-    fi
+        DST=$(dirname "${SRC}")/$(basename "${SRC}" | tr '[A-Z]' '[a-z]')
+        if [ "${SRC}" != "${DST}" ]; then
+            [ ! -e "${DST}" ] &&
+            $ESUDO mv -vT "${SRC}" "${DST}.temp" &&
+            $ESUDO mv -vT "${DST}.temp" "${DST}" ||
+                echo "- ${SRC} was not renamed"
+        fi
     done
 }
 

--- a/ports/fallout1/Fallout 1.sh
+++ b/ports/fallout1/Fallout 1.sh
@@ -20,10 +20,13 @@ PORTNAME="Fallout 1"
 
 to_lower_case() {
     for SRC in $(find "$1" -depth); do
-    DST=$(dirname "${SRC}")/$(basename "${SRC}" | tr '[A-Z]' '[a-z]')
-    if [ "${SRC}" != "${DST}" ]; then
-        [ ! -e "${DST}" ] && $ESUDO mv -vT "${SRC}" "${DST}" || echo "- ${SRC} was not renamed"
-    fi
+        DST=$(dirname "${SRC}")/$(basename "${SRC}" | tr '[A-Z]' '[a-z]')
+        if [ "${SRC}" != "${DST}" ]; then
+            [ ! -e "${DST}" ] &&
+            $ESUDO mv -vT "${SRC}" "${DST}.temp" &&
+            $ESUDO mv -vT "${DST}.temp" "${DST}" ||
+                echo "- ${SRC} was not renamed"
+        fi
     done
 }
 

--- a/ports/freesynd/Freesynd.sh
+++ b/ports/freesynd/Freesynd.sh
@@ -22,10 +22,13 @@ cd $GAMEDIR
 # Convert all filenames in the data directory to lowercase
 to_lower_case() {
     for SRC in $(find "$1" -depth); do
-    DST=$(dirname "${SRC}")/$(basename "${SRC}" | tr '[A-Z]' '[a-z]')
-    if [ "${SRC}" != "${DST}" ]; then
-        [ ! -e "${DST}" ] && $ESUDO mv -vT "${SRC}" "${DST}" || echo "- ${SRC} was not renamed"
-    fi
+        DST=$(dirname "${SRC}")/$(basename "${SRC}" | tr '[A-Z]' '[a-z]')
+        if [ "${SRC}" != "${DST}" ]; then
+            [ ! -e "${DST}" ] &&
+            $ESUDO mv -vT "${SRC}" "${DST}.temp" &&
+            $ESUDO mv -vT "${DST}.temp" "${DST}" ||
+                echo "- ${SRC} was not renamed"
+        fi
     done
 }
 


### PR DESCRIPTION
This was preventing these three games from running on CrossmixOS, which uses a FAT partition for ports.
Tested Fallout 1 after this and it works.