### PR TITLE
VHR: Update gmloader.json

### DIFF
--- a/ports/vhr/vhr/gmloader.json
+++ b/ports/vhr/vhr/gmloader.json
@@ -3,5 +3,5 @@
     "apk_path" : "vhr.port",
     "show_cursor" : false,
     "disable_controller" : false,
-    "force_platform" : "os_windows"
+    "force_platform" : "os_android"
 }


### PR DESCRIPTION
This makes it not crash. `os_type` is determined at runtime due to the xdelta and part of the patch requires `os_type` to be android.