### PR TITLE
sonic 2 updates for S2A mod

### DIFF
--- a/ports/sonic.2/README.md
+++ b/ports/sonic.2/README.md
@@ -11,7 +11,7 @@ Add your Sonic The Hedgehog 2 `Data.rsdk` file to `ports/sonic1`. You can retrie
 |DOWN + ABXY|Spindash|
 
 ## Using mods
-Open the dev menu by pressing Select and choose your mods to activate. The [Sonic 2 Absolute](https://teamforeveronline.wixsite.com/home/sonic-2-absolute) mod will use a custom binary to activate its menus.
+Open the dev menu by pressing Select and choose your mods to activate. The [Sonic 2 Absolute](https://teamforeveronline.wixsite.com/home/sonic-2-absolute) mod will use a custom binary to activate its menus. S2A 1.2.1 (and possibly later) will not work, you'll have to scroll down on the download page to download the latest mod-only version.
 
 ## Thanks
 christianhaitan -- the original port 

--- a/ports/sonic.2/Sonic 2.sh
+++ b/ports/sonic.2/Sonic 2.sh
@@ -62,7 +62,7 @@ else
 fi
 
 # Check if running Sonic 2 Absolute
-result=$(grep "^Sonic2Absolute=true" "$GAMEDIR/mods/modconfig.ini")
+result=$(grep -E "^(Sonic2Absolute|S2A)=true" "$GAMEDIR/mods/modconfig.ini")
 
 if [ -n "$result" ]; then
     GAME=sonic2absolute

--- a/ports/sonic.2/sonic2/mods/modconfig.ini
+++ b/ports/sonic.2/sonic2/mods/modconfig.ini
@@ -1,3 +1,4 @@
 
 [mods]
 S2A=false
+Sonic2Advance=false

--- a/ports/sonic.2/sonic2/mods/modconfig.ini
+++ b/ports/sonic.2/sonic2/mods/modconfig.ini
@@ -1,3 +1,3 @@
 
 [mods]
-Sonic2Absolute=false
+S2A=false


### PR DESCRIPTION
- update readme to notify users of the correct version of S2A to use
- update modconfig.ini to show the correct folder name for the most recent S2A mod
- update game launch script to look for the new mod name (preserving the old mod name for backwards compatibility)