### PR TITLE
Need for Speed II SE: Fix file renaming code, use bind_directories

### DIFF
--- a/ports/nfs2se/Need For Speed II SE.sh
+++ b/ports/nfs2se/Need For Speed II SE.sh
@@ -33,30 +33,13 @@ cd $GAMEDIR
 export LD_LIBRARY_PATH="/usr/lib/arm-linux-gnueabihf/":"/usr/lib32":"$GAMEDIR/libs/":"$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-$ESUDO rm -rf ~/.nfs2se
-ln -sfv /$directory/ports/nfs2se/conf/.nfs2se  ~/
+bind_directories ~/.nfs2se /$directory/ports/nfs2se/conf/.nfs2se
 
-
-# Process directories
-find . -depth -type d | grep -e "[A-Z]" | while read -r dir; do
-    newdir=$(echo "$dir" | tr '[A-Z]' '[a-z]' | sed 's/-1$//')
-    
-    # Simple progress message
-    echo "Renaming $dir" > "$CUR_TTY"
-    
-    mv "$dir" "$dir-1" > "$CUR_TTY"
-    mv "$dir-1" "$newdir" > "$CUR_TTY"
-done
-
-# Process files
-find . -type f | grep -e "[A-Z]" | while read -r file; do
-    newfile=$(echo "$file" | tr '[A-Z]' '[a-z]' | sed 's/-1$//')
-    
-    # Simple progress message
-    echo "Renaming $file" > "$CUR_TTY"
-    
-    mv "$file" "$file-1" > "$CUR_TTY"
-    mv "$file-1" "$newfile" > "$CUR_TTY"
+# Rename all game data files and directories to lower case
+find . -depth | grep -e "[A-Z]" | while read -r SRC; do
+  DST=`dirname "${SRC}"`/`basename "${SRC}" | tr '[A-Z]' '[a-z]'`
+  mv ${SRC} ${SRC}.1
+  mv ${SRC}.1 ${DST}
 done
 
 #export TEXTINPUTINTERACTIVE="Y"


### PR DESCRIPTION
NFSII renames files from upper case to lower case. When I installed it on ext4 (knulli, case-sensitive), it failed, producing lots of files like gamedata/sim/ai-1/PRSONAL.DAT-1-1. This is because, for example, the script tries to rename GAMEDATA/DASHHUD/PC/ to gamedata/dashhud/pc/ but the directory GAMEDATA/DASHHUD/ doesn't exist. It seems to me this problem will always occur unless the dirname and basename of the files are separated out, and only the basename is changed with each mv operation.

This PR fixes the problem and updates the port to use bind_directories.