### PR TITLE
Update launch scripts for RotT, Duke-AWO, Ion Fury, and Worship Vector

### DIFF
--- a/ports/duke3dawo/Duke3D - Alien World Order.sh
+++ b/ports/duke3dawo/Duke3D - Alien World Order.sh
@@ -44,7 +44,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 # Ensure Swap space is prepared or eduke32 may crash or fail to launch
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
-	  pm_message "Preparing Swap File, please wait..."
+    pm_message "Preparing Swap File, please wait..."
     [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
     [ -f /swapfile ] && $ESUDO rm -f /swapfile
     $ESUDO fallocate -l 384M /swapfile
@@ -53,7 +53,7 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     $ESUDO swapon /swapfile
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-	  pm_message "Preparing Swap File, please wait..."
+    pm_message "Preparing Swap File, please wait..."
     [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
     [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
     $ESUDO fallocate -l 384M /media/SHARE/swapfile

--- a/ports/duke3dawo/Duke3D - Alien World Order.sh
+++ b/ports/duke3dawo/Duke3D - Alien World Order.sh
@@ -13,11 +13,10 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
-GAMEDIR=/$directory/ports/duke3dawo
+GAMEDIR="/$directory/ports/duke3dawo"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
@@ -37,45 +36,41 @@ fi
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 $ESUDO rm $GAMEDIR/eduke32.log
 
-$ESUDO rm -rf ~/.config/eduke32
-$ESUDO ln -sfv "/$GAMEDIR/conf/eduke32" ~/.config/
+bind_directories ~/.config/eduke32 "$GAMEDIR/conf/eduke32"
 
 export DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 # Ensure Swap space is prepared or eduke32 may crash or fail to launch
-   $ESUDO chmod 666 /dev/tty0
-   printf "\033c" > /dev/tty0
-	 echo "Preparing Swap File, please wait..." > /dev/tty0
-	 echo " " > /dev/tty0
-if id "ark" &>/dev/null || id "odroid" &>/dev/null; then
-    $ESUDO swapoff /swapfile
+if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
+	  pm_message "Preparing Swap File, please wait..."
+    [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+    [ -f /swapfile ] && $ESUDO rm -f /swapfile
     $ESUDO fallocate -l 384M /swapfile
     $ESUDO chmod 600 /swapfile
     $ESUDO mkswap /swapfile
     $ESUDO swapon /swapfile
-else
-  if [ ! -f /storage/swapfile ]; then
-    $ESUDO swapoff /storage/swapfile
-    $ESUDO dd if=/dev/zero of=/storage/swapfile bs=1024 count=384k
-    $ESUDO chmod 600 /storage/swapfile
-    $ESUDO mkswap /storage/swapfile
-    $ESUDO sync
-    $ESUDO swapon /storage/swapfile
-  fi
+    [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
+elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
+	  pm_message "Preparing Swap File, please wait..."
+    [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
+    [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
+    $ESUDO fallocate -l 384M /media/SHARE/swapfile
+    $ESUDO chmod 600 /media/SHARE/swapfile
+    $ESUDO mkswap /media/SHARE/swapfile
+    $ESUDO swapon /media/SHARE/swapfile
+    [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 fi
 
-if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
+if [[ "${DEVICE_NAME^^}" == "X55" ]] || [[ "${DEVICE_NAME^^}" == "RG353P" ]] || [[ "${DEVICE_NAME^^}" == "RG40XX-H" ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/eduke32triggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/eduke32.gptk"
 fi
 
 $GPTOKEYB "eduke32.${DEVICE_ARCH}" -c "$GPTOKEYB_CONFIG" &
+pm_platform_helper "$GAMEDIR/eduke32.${DEVICE_ARCH}"
 ./eduke32.${DEVICE_ARCH} awo.zip -nosetup -gamegrp e32wt.grp -xE32WT.CON
 
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO systemctl restart oga_events &
-printf "\033c" > /dev/tty1
-printf "\033c" > /dev/tty0
+pm_finish

--- a/ports/ionfury/Ion Fury.sh
+++ b/ports/ionfury/Ion Fury.sh
@@ -13,20 +13,17 @@ else
 fi
 
 source $controlfolder/control.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/ionfury"
-
-export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
-export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $ESUDO chmod 777 -R $GAMEDIR/*
 
 sed -i 's/ScreenMode = 1/ScreenMode = 0/' $GAMEDIR/conf/eduke32/eduke32.cfg
 sed -i "s/ScreenWidth[[:space:]]*=[[:space:]]*[^[:space:]]*/ScreenWidth = $DISPLAY_WIDTH/" "$GAMEDIR/conf/eduke32/eduke32.cfg"
 sed -i "s/ScreenHeight[[:space:]]*=[[:space:]]*[^[:space:]]*/ScreenHeight = $DISPLAY_HEIGHT/" "$GAMEDIR/conf/eduke32/eduke32.cfg"
+sleep 0.3
 
 cd $GAMEDIR
 
@@ -34,21 +31,34 @@ cd $GAMEDIR
 $ESUDO rm $GAMEDIR/eduke32.log
 $ESUDO rm $GAMEDIR/fury.log
 
-bind_directories ~/.config/eduke32 $GAMEDIR/conf/eduke32
+bind_directories ~/.config/eduke32 "$GAMEDIR/conf/eduke32"
+
+export DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
+export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
+export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 # Ensure Swap space is prepared or eduke32 may crash or fail to launch
-printf "\033c" > /dev/tty0
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
-	  echo "Preparing Swap File, please wait..." > /dev/tty0
+	  pm_message "Preparing Swap File, please wait..."
     [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
     [ -f /swapfile ] && $ESUDO rm -f /swapfile
     $ESUDO fallocate -l 384M /swapfile
     $ESUDO chmod 600 /swapfile
     $ESUDO mkswap /swapfile
     $ESUDO swapon /swapfile
+    [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
+elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
+	  pm_message "Preparing Swap File, please wait..."
+    [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
+    [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
+    $ESUDO fallocate -l 384M /media/SHARE/swapfile
+    $ESUDO chmod 600 /media/SHARE/swapfile
+    $ESUDO mkswap /media/SHARE/swapfile
+    $ESUDO swapon /media/SHARE/swapfile
+    [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 fi
 
-if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == *'RG40XX'* ]]; then
+if [[ "${DEVICE_NAME^^}" == "X55" ]] || [[ "${DEVICE_NAME^^}" == "RG353P" ]] || [[ "${DEVICE_NAME^^}" == "RG40XX-H" ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/ionfurytriggers.gptk"  
 else
     GPTOKEYB_CONFIG="$GAMEDIR/ionfury.gptk"

--- a/ports/ionfury/Ion Fury.sh
+++ b/ports/ionfury/Ion Fury.sh
@@ -39,7 +39,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 # Ensure Swap space is prepared or eduke32 may crash or fail to launch
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
-	  pm_message "Preparing Swap File, please wait..."
+    pm_message "Preparing Swap File, please wait..."
     [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
     [ -f /swapfile ] && $ESUDO rm -f /swapfile
     $ESUDO fallocate -l 384M /swapfile
@@ -48,7 +48,7 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     $ESUDO swapon /swapfile
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-	  pm_message "Preparing Swap File, please wait..."
+    pm_message "Preparing Swap File, please wait..."
     [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
     [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
     $ESUDO fallocate -l 384M /media/SHARE/swapfile

--- a/ports/rott/Rise of the Triad - Dark War.sh
+++ b/ports/rott/Rise of the Triad - Dark War.sh
@@ -28,7 +28,7 @@ cd $GAMEDIR
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
-	  pm_message "Preparing Swap File, please wait..."
+    pm_message "Preparing Swap File, please wait..."
     [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
     [ -f /swapfile ] && $ESUDO rm -f /swapfile
     $ESUDO fallocate -l 384M /swapfile
@@ -37,7 +37,7 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     $ESUDO swapon /swapfile
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-	  pm_message "Preparing Swap File, please wait..."
+    pm_message "Preparing Swap File, please wait..."
     [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
     [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
     $ESUDO fallocate -l 384M /media/SHARE/swapfile

--- a/ports/rott/Rise of the Triad - The Hunt Begins.sh
+++ b/ports/rott/Rise of the Triad - The Hunt Begins.sh
@@ -28,7 +28,7 @@ cd $GAMEDIR
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
-	  pm_message "Preparing Swap File, please wait..."
+    pm_message "Preparing Swap File, please wait..."
     [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
     [ -f /swapfile ] && $ESUDO rm -f /swapfile
     $ESUDO fallocate -l 384M /swapfile
@@ -37,7 +37,7 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     $ESUDO swapon /swapfile
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-	  pm_message "Preparing Swap File, please wait..."
+    pm_message "Preparing Swap File, please wait..."
     [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
     [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
     $ESUDO fallocate -l 384M /media/SHARE/swapfile

--- a/ports/rott/Rise of the Triad - The Hunt Begins.sh
+++ b/ports/rott/Rise of the Triad - The Hunt Begins.sh
@@ -13,8 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/rott"
@@ -24,42 +23,42 @@ GAMEDIR="/$directory/ports/rott"
 [ ! -f "$GAMEDIR/conf/.rott/config.rot" ] && $ESUDO cp -f -v "$GAMEDIR/conf/.rott/config_bak.rot" "$GAMEDIR/conf/.rott/config.rot"
 [[ "$CFW_NAME" != *"ArkOS"* ]] && $ESUDO cp -f -v $GAMEDIR/timidity_cfg.bak $GAMEDIR/timidity.cfg
 
-$ESUDO chmod 777 -R $GAMEDIR/*
-
 cd $GAMEDIR
-
-$ESUDO chmod 666 /dev/tty0
-$ESUDO chmod 666 /dev/tty1
-$ESUDO chmod 666 /dev/uinput
 
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-printf "\033c" > /dev/tty0
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
-	  echo "Preparing Swap File, please wait..." > /dev/tty0
+	  pm_message "Preparing Swap File, please wait..."
     [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
     [ -f /swapfile ] && $ESUDO rm -f /swapfile
     $ESUDO fallocate -l 384M /swapfile
     $ESUDO chmod 600 /swapfile
     $ESUDO mkswap /swapfile
     $ESUDO swapon /swapfile
+    [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
+elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
+	  pm_message "Preparing Swap File, please wait..."
+    [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
+    [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
+    $ESUDO fallocate -l 384M /media/SHARE/swapfile
+    $ESUDO chmod 600 /media/SHARE/swapfile
+    $ESUDO mkswap /media/SHARE/swapfile
+    $ESUDO swapon /media/SHARE/swapfile
+    [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 fi
 
-$ESUDO rm -rf ~/.rott
-$ESUDO ln -sfv $GAMEDIR/conf/.rott ~/
+bind_directories ~/.rott $GAMEDIR/conf/.rott
 
 if [[ "$ANALOG_STICKS" == '1' ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/rott1joy.gptk"  
-elif [[ "$DEVICE_NAME" == 'x55' ]] || [[ "$DEVICE_NAME" == 'RG353P' ]]; then
-    GPTOKEYB_CONFIG="$GAMEDIR/rott_triggers.gptk"  
+elif [[ "$DEVICE_NAME" == "x55" ]] || [[ "$DEVICE_NAME" == "RG353P" ]] || [[ "$DEVICE_NAME" == "RG40XX-H" ]]; then
+    GPTOKEYB_CONFIG="$GAMEDIR/rott_triggers.gptk"
 else
     GPTOKEYB_CONFIG="$GAMEDIR/rott.gptk"
 fi
 
 $GPTOKEYB "rott_sw" -c "$GPTOKEYB_CONFIG" &
+pm_platform_helper "$GAMEDIR/rott_sw"
 ./rott_sw
 
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO systemctl restart oga_events &
-printf "\033c" > /dev/tty1
-printf "\033c" > /dev/tty0
+pm_finish

--- a/ports/worship_vector/Worship Vector.sh
+++ b/ports/worship_vector/Worship Vector.sh
@@ -27,8 +27,6 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 cd $GAMEDIR
 
-$ESUDO chmod 666 /dev/uinput
-
 $GPTOKEYB "worship.bin" -c "$GAMEDIR/worship.gptk" &
 ./worship.bin
 

--- a/ports/worship_vector/Worship Vector.sh
+++ b/ports/worship_vector/Worship Vector.sh
@@ -14,22 +14,22 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
+GAMEDIR="/$directory/ports/worship"
+
 export SDL12COMPAT_USE_GAME_CONTROLLERS=1
-export LD_LIBRARY_PATH="$PWD/libs:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$GAMEDIR/libs:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-GAMEDIR=/$directory/ports/worship
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
 cd $GAMEDIR
 
 $ESUDO chmod 666 /dev/uinput
 
-$GPTOKEYB "worship.bin" -c "./worship.gptk" &
+$GPTOKEYB "worship.bin" -c "$GAMEDIR/worship.gptk" &
 ./worship.bin
 
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO systemctl restart oga_events &
-printf "\033c" > /dev/tty0
+pm_finish


### PR DESCRIPTION
Update shell scripts for Rise of the Triad, Duke Nukem: Alien World Order, Ion Fury, and Worship Vector.
Add Knulli fixes for Rise of the Triad, Duke Nukem: Alien World Order, and Ion Fury.
Fix LD_LIBRARY_PATH in Worship Vector for muOS (Replaced $PWD with $GAMEDIR) as the libs were not being found - pointed to a non-existant path due to muOS directory structure.  This also fixed Worship Vector on my OGS running Ark as well!