### PR TITLE
Love 3: Move sound files to .apk to avoid case sensitivity problems

### DIFF
--- a/ports/love3/LOVE 3.sh
+++ b/ports/love3/LOVE 3.sh
@@ -46,6 +46,16 @@ fi
 [ -f "./gamedata/data.win" ] && mv gamedata/data.win gamedata/game.droid
 [ -f "./gamedata/game.unx" ] && mv gamedata/game.unx gamedata/game.droid
 
+# Move sound files to .apk (fixes case sensitivity problems)
+if [[ -d "gamedata/mus" ]]; then
+  echo "Zipping sound files into .apk..."
+  $ESUDO mkdir -p ./assets/
+  $ESUDO mv gamedata/sfx ./assets/
+  $ESUDO mv gamedata/mus ./assets/
+  $ESUDO zip -r -0 love3.apk ./assets/
+  $ESUDO rm -r ./assets/
+fi
+
 # Make sure uinput is accessible so we can make use of the gptokeyb controls
 $ESUDO chmod 666 /dev/uinput
 


### PR DESCRIPTION
The Love 3 port is missing music and some sound effects on case sensitive filesystems. This is because the files provided by the developer have different cases than those in the binary. For example:

```
$ strings game.droid | grep "\.ogg":
...
sfx/snd_leftFoot.ogg
sfx/snd_love11Switch.ogg
mus/love3/HUDSON.ogg
mus/love3/CADET.ogg
...
```

But:
```
$ find gamedata -type f
...
gamedata/sfx/snd_leftfoot.ogg
gamedata/sfx/snd_love11switch.ogg
gamedata/mus/love3/hudson.ogg
gamedata/mus/love3/cadet.ogg
...
```
This PR moves all the assets into the .apk file, which has case-insensitive lookup. This is simpler than correcting the case of all the files in gamedata/