### PR TITLE
Hexen2 & Portal of Praevus -- bind_directories

### DIFF
--- a/ports/hexen2/Hexen 2 - Portal of Praevus.sh
+++ b/ports/hexen2/Hexen 2 - Portal of Praevus.sh
@@ -13,9 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 
-#export PORT_32BIT="Y" # If using a 32 bit port
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -32,8 +30,7 @@ fi
 
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
-$ESUDO rm -rf ~/.hexen2
-$ESUDO ln -sfv $GAMEDIR/conf/.hexen2 ~/
+bind_directories ~/.hexen2 $GAMEDIR/conf/.hexen2
 $ESUDO cp -f "$GAMEDIR/conf/.hexen2/portals/config.cfg" "$GAMEDIR/portals/autoexec.cfg"
 
 export DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"

--- a/ports/hexen2/Hexen 2.sh
+++ b/ports/hexen2/Hexen 2.sh
@@ -13,9 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
 
-#export PORT_32BIT="Y" # If using a 32 bit port
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
@@ -32,8 +30,7 @@ fi
 
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
-$ESUDO rm -rf ~/.hexen2
-$ESUDO ln -sfv $GAMEDIR/conf/.hexen2 ~/
+bind_directories ~/.hexen2 $GAMEDIR/conf/.hexen2
 $ESUDO cp -f "$GAMEDIR/conf/.hexen2/data1/config.cfg" "$GAMEDIR/data1/autoexec.cfg"
 
 export DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"


### PR DESCRIPTION
Hexen2 & Portal of Praevus -- migrate to bind_directories. Load/save tested successfully on muOS/exFAT and knulli/ext4.

Note that `source $controlfolder/device_info.txt` has also been removed (I think by @t0b10-r3tr0). This looks correct to me, since this line is present in `$controlfolder/control.txt`.