### PR TITLE
Redneck Rampage Rides Again -- bind_directories

### DIFF
--- a/ports/redneck.rampage.rides.again/Redneck Rampage Rides Again.sh
+++ b/ports/redneck.rampage.rides.again/Redneck Rampage Rides Again.sh
@@ -13,7 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -44,8 +44,7 @@ GAMEDIR="/$directory/ports/rednukem-redneck2"
   fi
 # fi
 
-$ESUDO rm -rf ~/.config/rednukem
-$ESUDO ln -s $GAMEDIR/conf/rednukem ~/.config/
+bind_directories ~/.config/rednukem $GAMEDIR/conf/rednukem
 
 export LD_LIBRARY_PATH="$GAMEDIR/lib:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"

--- a/ports/redneck.rampage.rides.again/Redneck Rampage Rides Again.sh
+++ b/ports/redneck.rampage.rides.again/Redneck Rampage Rides Again.sh
@@ -51,13 +51,8 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 cd $GAMEDIR
 
-$ESUDO chmod 666 /dev/tty1
-$ESUDO chmod 666 /dev/uinput
-
 $GPTOKEYB "rednukem" &
+
 ./rednukem -game_dir $GAMEDIR/gamedata -gamegrp REDNECK.GRP
 
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO systemctl restart oga_events &
-printf "\033c" >> /dev/tty1
-
+pm_finish


### PR DESCRIPTION
Redneck Rampage Rides Again -- migrate to bind_directories. Load/save game tested on muOS/exFAT and knulli/ext4. Save files are produced in the correct location (`.config/rednukem/`) and switching between rednukem games works correctly.

Note that `source $controlfolder/device_info.txt` has also been removed (I think by @t0b10-r3tr0). This looks correct to me, since this line is present in `$controlfolder/control.txt`.