### PR TITLE
Tomb Raider 1: bind_dirs, update .sh

### DIFF
--- a/ports/tomb.raider.1/Tomb Raider 1.sh
+++ b/ports/tomb.raider.1/Tomb Raider 1.sh
@@ -14,22 +14,17 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/tombraider1"
 
 cd $GAMEDIR
 
-$ESUDO chmod 666 /dev/tty1
-
 $ESUDO ./oga_controls OpenLara $param_device &
-$ESUDO rm -rf ~/.openlara
-ln -sfv $GAMEDIR/conf/.openlara/ ~/
+bind_directories ~/.openlara $GAMEDIR/conf/.openlara/
 
 $ESUDO $controlfolder/oga_controls OpenLara $param_device &
 SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig" ./OpenLara 2>&1 | tee $GAMEDIR/log.txt
-$ESUDO kill -9 $(pidof oga_controls)
-$ESUDO systemctl restart oga_events &
+pm_finish
 printf "\033c" >> /dev/tty1
-


### PR DESCRIPTION
Tomb Raider 1: use bind_directories, update header remove unneeded chmods, use pm_finish

Tested on knulli/ext4 and muos/exfat.

On knulli, error 'Error launching, missing required parameters' is generated. This results from $param_device not being set, which is not specific to this port.
