### PR TITLE
Sonic 3 AIR -- bind_dirs, update .sh

### DIFF
--- a/ports/sonic3air/Sonic 3 AIR.sh
+++ b/ports/sonic3air/Sonic 3 AIR.sh
@@ -18,9 +18,6 @@ get_controls
 source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
-# Permissions
-$ESUDO chmod 777 $GAMEDIR/sonic3air_linux
-
 # Variables
 GAMEDIR="/$directory/ports/sonic3air"
 
@@ -45,7 +42,7 @@ WINDOW_SIZE="$DISPLAY_WIDTH x $DISPLAY_HEIGHT"
 
 # Modifies screen variables in files
 sed -i 's/"WindowSize": "[^"]*"/"WindowSize": "'"$WINDOW_SIZE"'"/' "$GAMEDIR/config.json"
-sed -i "s/\"Screen Width\" : [0-9]\+/\"Screen Width\" : $ASPECT/" "$GAMEDIR/.local/share/Sonic3AIR/settings.json"
+sed -i "s/\"Screen Width\" : [0-9]\+/\"Screen Width\" : $ASPECT/" "$GAMEDIR/config/settings.json"
 
 # Run the game
 $GPTOKEYB "sonic3air_linux" -c "sonic.gptk" &

--- a/ports/sonic3air/Sonic 3 AIR.sh
+++ b/ports/sonic3air/Sonic 3 AIR.sh
@@ -19,7 +19,6 @@ source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 # Permissions
-$ESUDO chmod 666 /dev/tty1
 $ESUDO chmod 777 $GAMEDIR/sonic3air_linux
 
 # Variables
@@ -34,8 +33,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 # Create config dir
 mkdir -p "config"
-rm -rf "$XDG_DATA_HOME/Sonic3AIR"
-ln -s "$GAMEDIR/config" "$XDG_DATA_HOME/Sonic3AIR"
+bind_directories "$XDG_DATA_HOME/Sonic3AIR" "$GAMEDIR/config"
 
 # Game only supports 4:3, 16:9 and 16:10 aspect ratios
 if [ $ASPECT_X == 16 ]; then
@@ -55,6 +53,5 @@ $GPTOKEYB "sonic3air_linux" -c "sonic.gptk" &
 
 # Cleanup
 unset HOME
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO systemctl restart oga_events &
+pm_finish
 printf "\033c" > /dev/tty1


### PR DESCRIPTION
Sonic 3 AIR -- update to bind_directories, remove unneeded chmods, use pm_finish

Also:  `$ESUDO chmod 777 $GAMEDIR/sonic3air_linux` fails because it happens before $GAMEDIR is set. Since the install process sets the executable bit anyway, I removed this line.

And: `sed -i "s/\"Screen Width\" : [0-9]\+/\"Screen Width\" : $ASPECT/" "$GAMEDIR/.local/share/Sonic3AIR/settings.json"` fails because the path does not exist. I have changed it to `"$GAMEDIR/config/settings.json"` which is the location of `settings.json`.

Tested on knulli/ext4 and muos/exfat.