### PR TITLE
fridaynightfunkin - enable ABXY buttons in gameplay

### DIFF
--- a/ports/fridaynightfunkin/README.md
+++ b/ports/fridaynightfunkin/README.md
@@ -25,7 +25,7 @@ Thanks to:
 |--|--| 
 |A|Action|
 |B|Back|
-|D-Pad/L-Stick/R-Stick|Moves|
+|D-Pad/L-Stick/R-Stick/ABXY|Moves|
 |L1/L2|Volume down|
 |R1/R2|Volume up|
 |Start|Pause|

--- a/ports/fridaynightfunkin/fridaynightfunkin/fridaynightfunkin.gptk
+++ b/ports/fridaynightfunkin/fridaynightfunkin/fridaynightfunkin.gptk
@@ -1,9 +1,9 @@
 back  = r
 start = p
-a = z
-b = x
-x = \"
-y = \"
+a = a
+b = b
+x = x
+y = y
 r1 = +
 r2 = +
 r3 = \"

--- a/ports/fridaynightfunkin/fridaynightfunkin/gamedata/funkin/backend/clientprefs.lua
+++ b/ports/fridaynightfunkin/fridaynightfunkin/gamedata/funkin/backend/clientprefs.lua
@@ -42,23 +42,23 @@ ClientPrefs.data = {
 }
 
 ClientPrefs.controls = {
-	note_left = {"key:a", "key:left"},
-	note_down = {"key:s", "key:down"},
-	note_up = {"key:w", "key:up"},
-	note_right = {"key:d", "key:right"},
+	note_left = {"key:y", "key:left"},
+	note_down = {"key:b", "key:down"},
+	note_up = {"key:x", "key:up"},
+	note_right = {"key:a", "key:right"},
 
-	ui_left = {"key:a", "key:left"},
-	ui_down = {"key:s", "key:down"},
-	ui_up = {"key:w", "key:up"},
-	ui_right = {"key:d", "key:right"},
+	ui_left = {"key:left"},
+	ui_down = {"key:down"},
+	ui_up = {"key:up"},
+	ui_right = {"key:right"},
 
 	volume_down = {"key:-", "key:kp-"},
 	volume_up = {"key:+", "key:kp+", "key:="},
 	volume_mute = {"key:0", "key:kp0"},
 
 	reset = {"key:r"},
-	accept = {"key:z", "key:space", "key:return"},
-	back = {"key:x", "key:backspace", "key:escape"},
+	accept = {"key:a", "key:space", "key:return"},
+	back = {"key:b", "key:backspace", "key:escape"},
 	pause = {"key:p", "key:return", "key:escape"},
 
 	fullscreen = {"key:f11"},


### PR DESCRIPTION
# Updated controls for Friday Night Funkin

## Changes
* Allows the face buttons (A, B, X, and Y) to be used in gameplay as directional arrows. 
* Changes the button mappings to be more clear in the Options menu (A corresponds to A on the gamepad, etc.)

## Rationale
This is analogous to the default configuration on PC where you have both WASD and the arrow keys available, letting you use both hands to alternate notes. The Playstation Dance Dance Revolution games are handled the same way when played with a controller, making this a familiar control scheme. This is especially useful for devices that are missing one or both joysticks, as playing the hardest songs using only the D-pad is uncomfortable and difficult.

The current settings don't even have the X or Y buttons mapped, making this impossible to configure yourself in-game (the B button being mapped to Back also makes it hard to set this button using the in-game options menu).