### PR TITLE
Adjust Mindustry Java runtime name

### DIFF
--- a/ports/mindustry/Mindustry.sh
+++ b/ports/mindustry/Mindustry.sh
@@ -48,7 +48,7 @@ zip -ur "${JAR_PACKAGE}" ./
 cd "${GAMEDIR}"
 
 # load runtime
-runtime="zulu17.54.21-ca-jre17.0.13-linux.aarch64"
+runtime="zulu17.54.21-ca-jre17.0.13-linux"
 export JAVA_HOME="$HOME/zulu17.54.21-ca-jre17.0.13-linux.aarch64"
 $ESUDO mkdir -p "${JAVA_HOME}"
 

--- a/ports/mindustry/port.json
+++ b/ports/mindustry/port.json
@@ -23,7 +23,7 @@
     "image": {},
     "rtr": true,
     "exp": false,
-    "runtime": "zulu17.54.21-ca-jre17.0.13-linux.aarch64.squashfs",
+    "runtime": "zulu17.54.21-ca-jre17.0.13-linux.squashfs",
     "reqs": [],
     "arch": [
       "aarch64"


### PR DESCRIPTION
This just updates the runtime name to remove the "aarch64" qualifier, as PM doesn't need it.
