### PR TITLE
Updated dRally port.

### DIFF
--- a/ports/drally/dRally.sh
+++ b/ports/drally/dRally.sh
@@ -12,47 +12,35 @@ else
   controlfolder="/roms/ports/PortMaster"
 fi
 
-source $controlfolder/control.txt
-if [ -z ${TASKSET+x} ]; then
-  source $controlfolder/tasksetter
-fi
+source $controlfolder/control.txt # We source the control.txt file contents here
+
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
-
-## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,
-CUR_TTY=/dev/tty0
 
 PORTDIR="/$directory/ports"
 GAMEDIR="$PORTDIR/drally"
 cd $GAMEDIR
 
-$ESUDO chmod 666 $CUR_TTY
-$ESUDO touch log.txt
-$ESUDO chmod 666 log.txt
-export TERM=linux
-printf "\033c" > $CUR_TTY
+> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
 ## RUN SCRIPT HERE
 if [ -f "DeathRallyWin_10.exe" ]; then
-  echo "Extracting DeathRallyWin_10.exe" > $CUR_TTY
+  pm_message "Extracting DeathRallyWin_10.exe"
   $EUSDO ./7z e -y DeathRallyWin_10.exe
   $EUSDO rm -f DeathRallyWin_10.exe
 fi
 
 if [ ! -f "TR0.BPA" ]; then
-  echo "Game files missing, check README for installation instructions." > $CUR_TTY
+  pm_message "Game files missing, check README for installation instructions."
   sleep 5
   exit
 fi
 
-echo "Starting game." > $CUR_TTY
+pm_message "Starting game."
 
 $GPTOKEYB "drally_linux" -c drally.gptk textinput &
-$TASKSET ./drally_linux 2>&1 | $ESUDO tee -a ./log.txt
+pm_platform_helper "$GAMEDIR/drally_linux"
+./drally_linux
 
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO systemctl restart oga_events &
-
-# Disable console
-printf "\033c" > $CUR_TTY
-
+pm_finish


### PR DESCRIPTION
This is an update to the existing port.

The game needs the original assets, they are freely available. Download the `DeathRallyWin_10.exe` from https://www.chip.de/downloads/Death-Rally-Vollversion_38550689.html and place it into the `ports/drally/` directory and it will be automatically extracted.

Custom Firmwares:
- [x] AmberELEC
- [x] ArkOS
- [x] ROCKNIX
- [x] MuOS
- [ ] Knulli**
- [ ] Crossmix **

Drivers: 
- [x] Mali
- [ ] Panfrost
- [x] Adreno **

Resolutions: 
- [x] 480x320 **
- [x] 640x480
- [ ] 720x720**
- [x] Higher resolutions