### PR TITLE
Add Mindustry analog stick requirements

### DIFF
--- a/ports/mindustry/port.json
+++ b/ports/mindustry/port.json
@@ -24,7 +24,7 @@
     "rtr": true,
     "exp": false,
     "runtime": "zulu17.54.21-ca-jre17.0.13-linux.squashfs",
-    "reqs": [],
+    "reqs": ["analog_2"],
     "arch": [
       "aarch64"
     ],


### PR DESCRIPTION
This port requires two analog sticks to play with the current keymap. It would be very difficult to create a map without analog sticks, as there's 3 different movement types (ship, cursor, menu navigation). This PR adds the requirements to port.json
