### PR TITLE
Descent: add numbersonlymode

### DIFF
--- a/ports/descent/Descent.sh
+++ b/ports/descent/Descent.sh
@@ -45,6 +45,8 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export SDL_FORCE_SOUNDFONTS=1
 export SDL_SOUNDFONTS="$GAMEDIR/soundfont.sf2"
 export TEXTINPUTPRESET=$CHEATS
+export TEXTINPUTINTERACTIVE="Y"
+export TEXTINPUTNUMBERSONLY="Y"
 
 # Edit .cfg file with updated resolution and aspect ratio
 sed -i "s/^ResolutionX=[0-9]\{1,4\}/ResolutionX=$DISPLAY_WIDTH/g" "$GAMEDIR/config/descent.cfg"

--- a/ports/descent2/Descent 2.sh
+++ b/ports/descent2/Descent 2.sh
@@ -45,6 +45,8 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export SDL_FORCE_SOUNDFONTS=1
 export SDL_SOUNDFONTS="$GAMEDIR/soundfont.sf2"
 export TEXTINPUTPRESET=$CHEATS
+export TEXTINPUTINTERACTIVE="Y"
+export TEXTINPUTNUMBERSONLY="Y"
 
 # Edit .cfg file with updated resolution and aspect ratio
 sed -i "s/^ResolutionX=[0-9]\{1,4\}/ResolutionX=$DISPLAY_WIDTH/g" "$GAMEDIR/config/descent.cfg"


### PR DESCRIPTION
Thanks to https://github.com/PortsMaster/gptokeyb/pull/3 and https://github.com/PortsMaster/PortMaster-GUI/pull/216 it is now possible to use a Numbers Only mode with textinput. Implement it here. Tested and verified.