### PR TITLE
New Runtimes: Westonpack (X11 Compatibility layer) and Mesapack (OpenGL Graphics stack)

### DIFF
--- a/ports/mindustry/port.json
+++ b/ports/mindustry/port.json
@@ -24,7 +24,7 @@
     "rtr": true,
     "exp": false,
     "runtime": "zulu17.54.21-ca-jre17.0.13-linux.squashfs",
-    "reqs": [],
+    "reqs": ["analog_2"],
     "arch": [
       "aarch64"
     ],

--- a/runtimes/runtimes.json
+++ b/runtimes/runtimes.json
@@ -90,6 +90,13 @@
             "aarch64": "frt_4.1.3.aarch64.squashfs"
         }
     },
+    "mesa_pkg_0.1.squashfs": {
+        "name": "Mesapack 0.1",
+        "default": "aarch64",
+        "arch": {
+            "aarch64": "mesa_pkg_0.1.aarch64.squashfs"
+        }
+    },
     "mono-6.12.0.122-aarch64.squashfs": {
         "name": "Mono 6.12.0.122",
         "default": "aarch64",
@@ -117,6 +124,13 @@
         "default": "aarch64",
         "arch": {
             "aarch64": "solarus-1.6.5.aarch64.squashfs"
+        }
+    },
+    "weston_pkg_0.2.squashfs":  {
+        "name": "Westonpack 0.2",
+        "default": "aarch64",
+        "arch": {
+            "aarch64": "weston_pkg_0.2.aarch64.squashfs"
         }
     },
     "zulu11.48.21-ca-jdk11.0.11-linux.aarch64.squashfs":  {


### PR DESCRIPTION
It's finally here! 

This is Westonpack, a runtime that aims to make games with X11 dependencies playable on non-X11 platforms.

This pack includes:

- Weston - A wayland compositor (Heavily modified)
- XWayland - A Wayland compatible XServer
- Seatd - Graphics and input management for Weston
- GL4ES - GL2 on GLES emulation layer (Multiple versions, modified to work with crusty)
- Crusty - My own compatibility layer, mapping GLX and EGL into a SDL2 window
- Many X11 support libraries

This enables many new ports running on many more engines, such as:

- Godot 4
- libGDX
- SDL2 (that previously crashed)
- Monogame
- Unity (maybe, to be determined)
- Custom Engines

This runtime works on ArkOS, AmberELEC, muOS, Knulli (except a133p devices). It also partially works on Rocknix. Compatibility will improve.

---

Mesapack is a runtime that contains a build of the graphics stack mesa, aiming to bring Desktop GL support to Westonpack.

This pack includes:

- LLVMPipe: Run OpenGL 4.5 apps software rendered
- VirGL: Run OpenGL 2.1 apps hardware rendered (virtualized)
- Zink: Run OpenGL 4.5 apps hardware rendered if you have Vulkan
- Gallium Nine: Run DirectX 9 games on one of the above (with Wine)

This enables new ports on engines that don't work with Westonpack and GL4ES yet, for example Windows games through Wine.

This runtime works on ArkOS, AmberELEC, muOS, Knulli, and Rocknix.