### PR TITLE
fix sigil.doom file locations

### DIFF
--- a/ports/doomengines/doomengines/doomfiles/Addons/Sigil.doom
+++ b/ports/doomengines/doomengines/doomfiles/Addons/Sigil.doom
@@ -1,5 +1,5 @@
-IWAD=iwads/official/DOOM.WAD
-MOD=iwads/official/sigil.wad
+IWAD=iwads/DOOM.WAD
+MOD=iwads/sigil.wad
 DIFF=3
 MAP=e5m1
 -- end --


### PR DESCRIPTION
this is the only preconfigured .doom file that has /official/ folder