### PR TITLE
Fix typo in dRally.sh

### DIFF
--- a/ports/drally/dRally.sh
+++ b/ports/drally/dRally.sh
@@ -27,8 +27,8 @@ cd $GAMEDIR
 ## RUN SCRIPT HERE
 if [ -f "DeathRallyWin_10.exe" ]; then
   pm_message "Extracting DeathRallyWin_10.exe"
-  $EUSDO ./7z e -y DeathRallyWin_10.exe
-  $EUSDO rm -f DeathRallyWin_10.exe
+  $ESUDO ./7z e -y DeathRallyWin_10.exe
+  $ESUDO rm -f DeathRallyWin_10.exe
 fi
 
 if [ ! -f "TR0.BPA" ]; then


### PR DESCRIPTION
Just fixes two misspellings of $ESUDO. I don't think it matters, since the files that are touched are local to the port directory, but doesn't hurt to correct it.