### PR TITLE
Hammerwatch: Fix runtime name and readme typos

### DIFF
--- a/ports/hammerwatch/README.md
+++ b/ports/hammerwatch/README.md
@@ -39,9 +39,9 @@ This port uses the new Westonpack runtime and libcrusty to provide X11 compatibi
 |--|--| 
 |Analog Sticks, DPad |Movement|
 |A|Attack|
-|B, Ability 1|
-|Y, Ability 2|
-|X, Ability 3|
+|B|Ability 1|
+|Y|Ability 2|
+|X|Ability 3|
 |L1|Strafe|
 |L2|Hold|
 |R1|Autofire Hold|

--- a/ports/hammerwatch/port.json
+++ b/ports/hammerwatch/port.json
@@ -22,7 +22,7 @@
     "image": null,
     "rtr": false,
     "exp": false,
-    "runtime": ["weston_pkg_0.2.squashfs","mono-6.12.0.122.squashfs"],
+    "runtime": ["weston_pkg_0.2.squashfs","mono-6.12.0.122-aarch64.squashfs"],
     "reqs": [],
     "arch": [
       "aarch64"


### PR DESCRIPTION
This fixes the port.json to download "mono-6.12.0.122-aarch64.squashfs" instead of "mono-6.12.0.122.squashfs". It also fixes a typo in the README file in the table of controls.
