### PR TITLE
OpenEnroth: Delete installer after use

### DIFF
--- a/ports/openenroth/openenroth/tools/patchscript
+++ b/ports/openenroth/openenroth/tools/patchscript
@@ -22,3 +22,6 @@ EXE=$(find "$DATADIR" -maxdepth 1 -name "setup*.exe")
 "$TOOLDIR/innoextract" -e -d "$DATADIR" $EXE
 mv "$DATADIR"/app/* "$DATADIR/"
 rm -rf "$DATADIR/tmp"
+
+# Delete installer
+rm "$DATADIR"/setup*.exe


### PR DESCRIPTION
GoG installer should be deleted after files have been extracted