### PR TITLE
Update GrazeCounterGM, fix README instructions

### DIFF
--- a/ports/grazecountergm/README.md
+++ b/ports/grazecountergm/README.md
@@ -5,7 +5,7 @@ This port supports Steam version of the game. On devices with the RK3326 process
 ## Instructions for Running
 
 - Purchase game via https://store.steampowered.com/app/1486440/Graze_Counter_GM/
-- Place all game .dat and .win files in the "/gamedata/" folder. 
+- Place all game .dat and .win files in the "/assets/" folder. 
 - On first run, the game will take a ~5 minutes to load. The port is running through compressing audio files and packing files into the .apk. Subsequent starts should go faster. 
 
 ## Controls


### PR DESCRIPTION
This is a correction for the README.md on GrazeCounterGM

The instructions say to put files in a "/gamedata/" folder that does not exist and will not be used. I have corrected it to "/assets/" which is the directory the shell scripts look for these files.

Things to note:
I made this edit via the github web interface to avoid cloning the repo to my system. It appears it changed the EOF indicator when doing so. Not sure if this affects anything.