### PR TITLE
Add support for Miyoo to RetroArch Games

### DIFF
--- a/ports/2048/2048.sh
+++ b/ports/2048/2048.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+elif [[ $CFW_NAME == "Miyoo" ]]; then
+  raloc="/mnt/sdcard/RetroArch"
+  raconf=""
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/cannonball-lr/Cannonball.sh
+++ b/ports/cannonball-lr/Cannonball.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+elif [[ $CFW_NAME == "Miyoo" ]]; then
+  raloc="/mnt/sdcard/RetroArch"
+  raconf=""
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/cave.story/Cave Story.sh
+++ b/ports/cave.story/Cave Story.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+elif [[ $CFW_NAME == "Miyoo" ]]; then
+  raloc="/mnt/sdcard/RetroArch"
+  raconf=""
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/dinothawr/Dinothawr.sh
+++ b/ports/dinothawr/Dinothawr.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+elif [[ $CFW_NAME == "Miyoo" ]]; then
+  raloc="/mnt/sdcard/RetroArch"
+  raconf=""
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/mr.boom/Mr. Boom.sh
+++ b/ports/mr.boom/Mr. Boom.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+elif [[ $CFW_NAME == "Miyoo" ]]; then
+  raloc="/mnt/sdcard/RetroArch"
+  raconf=""
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/quake/Quake.sh
+++ b/ports/quake/Quake.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+elif [[ $CFW_NAME == "Miyoo" ]]; then
+  raloc="/mnt/sdcard/RetroArch"
+  raconf=""
 else
   raloc="/usr/bin"
   raconf=""

--- a/ports/rick.dangerous/Rick Dangerous.sh
+++ b/ports/rick.dangerous/Rick Dangerous.sh
@@ -33,6 +33,9 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   else
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
   fi
+elif [[ $CFW_NAME == "Miyoo" ]]; then
+  raloc="/mnt/sdcard/RetroArch"
+  raconf=""
 else
   raloc="/usr/bin"
   raconf=""


### PR DESCRIPTION
- Set path to RA for retroarch games for Miyoo Devices 
- The config can be left blank and the Miyoo Flip can be setup to launch the port w/ the config automatically
- I verified all games booted and the menu worked on the MiyooFlip. I have not actively played through them


# Updating Port for Quake

## Game Information
- **Title**:: Quake
- **URL**: https://portmaster.games/detail.html?name=quake

## Submission Requirements

### CFW Tests
Ensure your game has been tested on all major CFWs:
- [ ] AmberELEC
- [ ] ArkOS
- [ ] ROCKNIX
- [ ] muOS

### Resolution Tests
Test all major resolutions:
- [ ] 480x320
- [ ] 640x480
- [ ] 720x720 (RGB30)
- [ ] Higher resolutions (e.g., 1280x720)

## File Structure
- Your port should have the following structure:
  - portname/
    - port.json
    - README.md
    - screenshot.jpg
    - cover.jpg
    - gameinfo.xml
    - Port Name.sh
    - portname/
      - <portfiles here>

## Additional Resources
For an in-depth guide on creating a pull request, refer to: [PortMaster Game Packaging Guide](https://portmaster.games/packaging.html#creating-a-pull-request)
