### PR TITLE
New Runtime: Zulu Java JRE 23

### DIFF
--- a/runtimes/runtimes.json
+++ b/runtimes/runtimes.json
@@ -196,5 +196,12 @@
             "x86_64": "zulu17.48.15-ca-jdk17.0.10-linux.x86_64.squashfs",
             "armhf": "zulu17.48.15-ca-jdk17.0.10-linux.armhf.squashfs"
         }
+    },
+    "zulu23.32.11-ca-jre23.0.2-linux.squashfs":  {
+        "name": "Java jre23.0.2",
+        "default": "aarch64",
+        "arch": {
+            "aarch64": "zulu23.32.11-ca-jre23.0.2-linux.aarch64.squashfs"
+        }
     }
 }


### PR DESCRIPTION
Same usage as the existing Zulu 17 JRE runtime, just a newer java version.