### PR TITLE
Void Stranger: 1.1.2 not supported yet

### DIFF
--- a/ports/voidstranger/README.md
+++ b/ports/voidstranger/README.md
@@ -2,15 +2,15 @@
 
 GitHub for this port- https://github.com/EzDzzIt/vsaarch64
  
-This port supports v1.1.1 of the Steam version of the game, or v1.1.1 of the itch.io version (itch version is patched to be equivalent to the Steam version).
+This port currently supports **v1.1.1** of the Steam version of the game, or v1.1.1 of the itch.io version (itch version is patched to be equivalent to the Steam version).
 
 ## Instructions for Running
 
--Purchase game via https://store.steampowered.com/app/2121980/Void_Stranger/ 
-
--Place all game .png, .dat, .csv, and .win files in the "/gamedata/" folder. 
-
--On first run, the game will take a 2-4 minutes to load. The port is running through patching the data.win file via xdelta, zipping audio files and other files into the .apk, and parsing the .csv game data file. Subsequent starts should go faster. 
+- Purchase game via https://store.steampowered.com/app/2121980/Void_Stranger/ 
+- In Steam, right-click the game and select "Properties..."
+- In the "Betas" tab, choose `old_version_1.1.1`. Let Steam download this version.
+- Place all game .png, .dat, .csv, and .win files in the "/gamedata/" folder. 
+- On first run, the game will take a 2-4 minutes to load. The port is running through patching the data.win file via xdelta, zipping audio files and other files into the .apk, and parsing the .csv game data file. Subsequent starts should go faster. 
 
 ## Controls
 

--- a/ports/voidstranger/port.json
+++ b/ports/voidstranger/port.json
@@ -13,7 +13,7 @@
     ],
     "desc": "A sokoban-style puzzle adventure. Traverse a forgotten labyrinth in search of your memories. Do you remember why you are here?",
     "desc_md": "*Void Stranger* is a 2D sokoban-style puzzle game where every step counts. Descend into the forgotten labyrinth teeming with fiendish foes and traps that defy reason. A swift defeat lurks at every corner for those who neither study their surroundings nor think their moves through with care.\nTrust you wits and slowly, surely, you will conquer the mysteries before you.\n\nYou do remember why you are here, right? Or have you lost something? Something very important to you.",
-    "inst": "Place game .png, .dat, .csv, and .win files in the \"gamedata\" folder. Game must be v1.1.1, Steam or Itch supported. The game will take 3-5 minutes to boot for the first time only.",
+    "inst": "Place game .png, .dat, .csv, and .win files in the \"gamedata\" folder. Game must be v1.1.1, Steam or Itch supported (not v1.1.2). The game will take 3-5 minutes to boot for the first time only.",
     "inst_md": "Purchase the game via [Steam](https://store.steampowered.com/app/2121980/Void_Stranger/) or [Itch](https://system-erasure.itch.io/void-stranger).\nCurrently supporting v1.1.1 off Steam and Itch.\nPlace all `.png`, `.dat`, `.csv`, and `.win` files in the `gamedata` folder.\nThe game will take 3-5 minutes to boot for the first time only.",
     "genres": [
       "puzzle",


### PR DESCRIPTION
This is just a small change to the instructions for Void Stranger's port, as it received an update today that is not yet supported by this port (the xdelta patch is only for v1.1.1, not v1.1.2). The instructions now clearly outline that 1.1.2 is not supported and that the supported version can be installed through Steam's open beta tab.