### PR TITLE
Dicey Dungeons: Fix controls on muos

### DIFF
--- a/ports/diceydungeons/Dicey Dungeons.sh
+++ b/ports/diceydungeons/Dicey Dungeons.sh
@@ -71,7 +71,12 @@ if [[ "$CFW_NAME" = "ROCKNIX" ]]; then
   export rocknix_mode=1
 fi
 
-$GPTOKEYB "$BINARY" xbox360 &
+# gptokeyb1 is unresponsive on muos
+if [[ "$CFW_NAME" = "muOS" ]]; then
+  $GPTOKEYB2 "$BINARY" -x &
+else
+  $GPTOKEYB "$BINARY" xbox360 &
+fi
 
 cd $DATADIR
 


### PR DESCRIPTION
Switching to gptokeyb1 (for ArkOS compatibility) broke the controls on muOS. We should fix xbox360 mode, but for now, this fixes the controls on muOS.