### PR TITLE
Abes Adventure - bind directories

### DIFF
--- a/ports/abes_adventure/Abes Adventure.sh
+++ b/ports/abes_adventure/Abes Adventure.sh
@@ -13,7 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 get_controls
 
@@ -27,8 +27,7 @@ cd $GAMEDIR
 export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-$ESUDO rm -rf ~/.abe
-ln -sfv /$directory/ports/abes_adventure/conf/.abe ~/
+bind_directories ~/.abe /$directory/ports/abes_adventure/conf/.abe
 
 $GPTOKEYB "abe.${DEVICE_ARCH}" -c "./abe.gptk" &
 ./abe.${DEVICE_ARCH}


### PR DESCRIPTION
Abe's Adventure previously used symbolic links and has been changed to use a bind mount for compatibility reasons.

Tests passed in Knulli (exFAT) and ROCKNIX (ext4).