### PR TITLE
[RomM] Update launchscript

### DIFF
--- a/ports/romm/RomM App.sh
+++ b/ports/romm/RomM App.sh
@@ -79,9 +79,9 @@ else
     PYTHON_VERSION="0.0"
 fi
 
-REQUIRED_VERSION="3.10"
+REQUIRED_VERSION="3.11"
 
-if ! compare "$PYTHON_VERSION" "$REQUIRED_VERSION"; then
+if [ "$PYTHON_VERSION" != "$REQUIRED_VERSION" ]; then
     use_runtime
 fi
 


### PR DESCRIPTION
RomM App requires python 3.11. Knulli Gladiator uses python 3.12, which breaks the app. Fix the launchscript to ensure the runtime is mounted if there is no system python 3.11.