### PR TITLE
Steamworld Dig Panfrost/Adreno fix

### DIFF
--- a/ports/steamworlddig/Steamworld Dig.sh
+++ b/ports/steamworlddig/Steamworld Dig.sh
@@ -22,15 +22,6 @@ CONFDIR="$GAMEDIR/savedata/"
 mkdir -p "$GAMEDIR/savedata/"
 cd "$GAMEDIR/"
 
-# Warn about Panfrost incompatability on ROCKNIX
-if [[ "$CFW_NAME" = "ROCKNIX" ]]; then
-    if glxinfo | grep "OpenGL version string"; then
-    pm_message "This Port only supports the libMali graphics driver. Switch to from Panfrost to libMali to continue."
-    sleep 5
-    exit 1
-    fi
-fi
-
 # Unpack GOG Files
 $ESUDO chmod 777 "$GAMEDIR/unzip"
 LD_LIBRARY_PATH="$GAMEDIR/tools/libs.aarch64"
@@ -79,7 +70,7 @@ pm_platform_helper "$GAMEDIR/box86.${DEVICE_ARCH}"
 $ESUDO env WRAPPED_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}/":"$GAMEDIR/box86/native":"/usr/lib":"/usr/lib32" $weston_dir/westonwrap32.sh headless noop kiosk crusty_glx_gl4es \
 BOX86_LD_LIBRARY_PATH="$GAMEDIR/box86/lib:/usr/lib32/:./:lib/:lib32/:x86/" \
 LIBGL_NOBANNER=1 BOX86_DYNAREC=1 BOX86_DLSYM_ERROR=1 BOX86_SHOWSEGV=1 BOX86_SHOWBT=1 \
-XDG_DATA_HOME=$CONFDIR "$GAMEDIR/box86/box86" "$GAMEDIR/SteamWorldDig"
+XDG_DATA_HOME=$CONFDIR SDL_VIDEODRIVER=x11 "$GAMEDIR/box86/box86" "$GAMEDIR/SteamWorldDig"
 
 
 #Clean up after ourselves


### PR DESCRIPTION
This makes the game run on both Panfrost and Adreno drivers. Thanks to Moerlin on discord for figuring it out. 

## File Structure
- Your port should have the following structure:
  - portname/
    - port.json
    - README.md
    - screenshot.png
    - cover.png
    - gameinfo.xml
    - Port Name.sh
    - portname/
      - <portfiles here>

## Additional Resources
For an in-depth guide on creating a pull request, refer to: [PortMaster Game Packaging Guide](https://portmaster.games/packaging.html#creating-a-pull-request)
