### PR TITLE
[DELTARUNE] - Update gptokeyb mode

### DIFF
--- a/ports/deltarune/Deltarune.sh
+++ b/ports/deltarune/Deltarune.sh
@@ -72,7 +72,7 @@ check_patch() {
 check_patch
 
 # Assign gptokeyb and load the game
-$GPTOKEYB "gmloadernext.aarch64" -k &
+$GPTOKEYB "gmloadernext.aarch64" &
 pm_platform_helper "$GAMEDIR/gmloadernext.aarch64" >/dev/null
 ./gmloadernext.aarch64 -c gmloader.json
 

--- a/ports/deltarune/Deltarune.sh
+++ b/ports/deltarune/Deltarune.sh
@@ -72,7 +72,7 @@ check_patch() {
 check_patch
 
 # Assign gptokeyb and load the game
-$GPTOKEYB "gmloadernext.aarch64" xbox360 &
+$GPTOKEYB "gmloadernext.aarch64" -k &
 pm_platform_helper "$GAMEDIR/gmloadernext.aarch64" >/dev/null
 ./gmloadernext.aarch64 -c gmloader.json
 


### PR DESCRIPTION
Xbox360 mode was causing phantom inputs on some devices and firmwares.