### PR TITLE
Update port.json for Devilutionx to include x86_64 to show for Steam deck after recent merge

### DIFF
--- a/ports/devilutionx/port.json
+++ b/ports/devilutionx/port.json
@@ -23,7 +23,8 @@
         "reqs": [],
         "arch": [
             "aarch64",
-            "armhf"
+            "armhf",
+            "x86_64"
         ]
     }
 }


### PR DESCRIPTION
Super small tweak, but previous commit did not have port.json updated and I realized that even with the x86 changes it did not show up when selecting Steam Deck in website.  