### PR TITLE
fix Jagged Alliance 2 ready-to-run flag

### DIFF
--- a/ports/jaggedalliance2/port.json
+++ b/ports/jaggedalliance2/port.json
@@ -19,7 +19,7 @@
       "strategy"
     ],
     "image": null,
-    "rtr": true,
+    "rtr": false,
     "exp": false,
     "runtime": [],
     "store": [


### PR DESCRIPTION
The Jagged Alliance 2 port requires original gamefiles, but it's tagged as "Ready to run" by mistake. This PR fixes it.
Thank you @tabreturn for point it out!