### PR TITLE
add mod_CFW support to fix blank DEVICE_ARCH in a few games I recently touched

### DIFF
--- a/ports/fheroes2/Fheroes2.sh
+++ b/ports/fheroes2/Fheroes2.sh
@@ -14,7 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/fheroes2

--- a/ports/jazz2/Jazz2 Resurrection.sh
+++ b/ports/jazz2/Jazz2 Resurrection.sh
@@ -18,7 +18,7 @@ else
 fi
 
 source $controlfolder/control.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 CUR_TTY=/dev/tty0

--- a/ports/openjazz/OpenJazz.sh
+++ b/ports/openjazz/OpenJazz.sh
@@ -13,7 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/openjazz"

--- a/ports/openxcom/OpenXcomEX.sh
+++ b/ports/openxcom/OpenXcomEX.sh
@@ -14,7 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty1

--- a/ports/sdlpop/SDLPoP.sh
+++ b/ports/sdlpop/SDLPoP.sh
@@ -13,7 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty1


### PR DESCRIPTION
added mod_CFW support to fix blank DEVICE_ARCH issue in any game I recently added x86 support for due to a report in SDLPop and Jazz2:
only changes are:
[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
