### PR TITLE
[Undertale Yellow] Fix ArkOS issue (ESUDO required for umount and mount)

### DIFF
--- a/ports/utyellow/Undertale Yellow.sh
+++ b/ports/utyellow/Undertale Yellow.sh
@@ -26,6 +26,7 @@ cd $GAMEDIR
 # Exports
 export LD_LIBRARY_PATH="/usr/lib:$GAMEDIR/lib:$GAMEDIR/libs:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
+export ESUDO
 
 # Check if patchlog.txt to skip patching
 if [ ! -f patchlog.txt ] || [ -f "$GAMEDIR/assets/data.win" ]; then


### PR DESCRIPTION
Fix an install issue for Undertale Yellow on ArkOS. See this [post](https://discord.com/channels/1122861252088172575/1390128580998201394/1394204147317735434) on discord for more details.

```
MEDIR is set to: /roms/ports/utyellow
umount: /home/ark/gmtoolkit: not mounted.
mount: only root can do that
umount: /opt/system/Tools/PortMaster/libs/dotnet-8.0.12.squashfs: not mounted.
mount: only root can do that
chmod: changing permissions of '/dev/uinput': Operation not permitted
Preparing game...
Externalizing textures...
/roms/ports/utyellow/tools/patchscript: line 100: dotnet: command not found
[DOTNET]: Texture dumping failed to apply.
mv: cannot move '/roms/ports/utyellow/patchlog.txt' to '': No such file or directory
Patching process failed.
Cleaned up temporary files.
```