### PR TITLE
TBOI: Rebirth Rocknix Fixes

### DIFF
--- a/ports/tboirebirth/Binding Of Isaac Rebirth.sh
+++ b/ports/tboirebirth/Binding Of Isaac Rebirth.sh
@@ -144,6 +144,7 @@ if [[ "$CFW_NAME" = "ROCKNIX" ]]; then
     fi
 fi
 
+pm_platform_helper "$GAMEDIR/gamefiles/$game_executable" >/dev/null
 $ESUDO env $gl4es_params WRAPPED_PRELOAD=$input_blocker_preload CRUSTY_BLOCK_INPUT=1 $weston_dir/westonwrap.sh headless noop kiosk crusty_glx_gl4es \
 XDG_DATA_HOME=$CONFDIR BOX64_DYNAREC_CALLRET=1 BOX64_LD_PRELOAD=$box_preload BOX64_LD_LIBRARY_PATH=$GAMEDIR/libs.x64/:$GAMEDIR/gamefiles/lib64/ \
 $GAMEDIR/box64 $game_executable


### PR DESCRIPTION
This updates the TBOI launchscript to include `pm_platform_helper` to hopefully make the game work in fullscreen on Rocknix Panfrost/Snapdragon.
It also fixes a typo in Westonpack that causes the game to not exit properly and stay stuck until force close or restart. This bumps the WP version number to 0.2.7.1.