### PR TITLE
Fix for Blake Stone

### DIFF
--- a/ports/bstone-aog/Blake Stone - Aliens of Gold.sh
+++ b/ports/bstone-aog/Blake Stone - Aliens of Gold.sh
@@ -13,18 +13,17 @@ else
 fi
 
 source $controlfolder/control.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/bstone-aog"
 
-$ESUDO chmod 777 -R $GAMEDIR/*
-
-if [[ "${CFW_NAME^^}" == "MUOS" ]] || [[ "${CFW_NAME^^}" == "TRIMUI" ]]; then
-    sed -i 's/^\(vid_renderer\s*\)"[^"]*"/\1"software"/' "$GAMEDIR/conf/bibendovsky/bstone/bstone_config.txt"
-else
+if [[ "${CFW_NAME^^}" == *"ARKOS"* ]] || [[ "${CFW_NAME^^}" == "AMBERELEC" ]] || [[ "${CFW_NAME^^}" == "ROCKNIX" ]]; then
     sed -i 's/^\(vid_renderer\s*\)"[^"]*"/\1"gles_2_0"/' "$GAMEDIR/conf/bibendovsky/bstone/bstone_config.txt"
+elif [[ "${CFW_NAME^^}" == "RETRODECK" ]]; then
+    sed -i 's/^\(vid_renderer\s*\)"[^"]*"/\1"gl_2_0"/' "$GAMEDIR/conf/bibendovsky/bstone/bstone_config.txt"
+else
+    sed -i 's/^\(vid_renderer\s*\)"[^"]*"/\1"software"/' "$GAMEDIR/conf/bibendovsky/bstone/bstone_config.txt"
 fi
 
 cd $GAMEDIR
@@ -37,12 +36,14 @@ export DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
+$ESUDO chmod +x "$GAMEDIR/bstone.${DEVICE_ARCH}"
+
 if [[ -f "$GAMEDIR/gamedata/aliens_of_gold/VSWAP.BS1" ]] && [[ -f "$GAMEDIR/gamedata/aliens_of_gold/VSWAP.BS6" ]]; then
     rm -f "$GAMEDIR/gamedata/aliens_of_gold/"*.BS1
     sleep 0.5
 fi
 
-if [[ "$DEVICE_NAME" == "x55" ]] || [[ "$DEVICE_NAME" == "RG353P" ]] || [[ "$DEVICE_NAME" == "RG40XX-H" ]]; then
+if [[ "${DEVICE_NAME^^}" == "X55" ]] || [[ "${DEVICE_NAME^^}" == "RG353P" ]] || [[ "${DEVICE_NAME^^}" == "RG40XX-H" ]] || [[ "${CFW_NAME^^}" == "RETRODECK" ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/bstonetriggers.gptk"
 else
     GPTOKEYB_CONFIG="$GAMEDIR/bstone$ANALOG_STICKS.gptk"
@@ -50,6 +51,6 @@ fi
 
 $GPTOKEYB "bstone.${DEVICE_ARCH}" -c "$GPTOKEYB_CONFIG" &
 pm_platform_helper "$GAMEDIR/bstone.${DEVICE_ARCH}"
-./bstone.${DEVICE_ARCH} --vid_windowed_width $DISPLAY_WIDTH --vid_windowed_height $DISPLAY_HEIGHT --profile_dir $GAMEDIR/conf/bibendovsky/bstone --data_dir $GAMEDIR/gamedata/aliens_of_gold $ADDLPARAMS
+./bstone.${DEVICE_ARCH} --vid_windowed_width $DISPLAY_WIDTH --vid_windowed_height $DISPLAY_HEIGHT --profile_dir $GAMEDIR/conf/bibendovsky/bstone --data_dir $GAMEDIR/gamedata/aliens_of_gold
 
 pm_finish

--- a/ports/bstone-aog/README.md
+++ b/ports/bstone-aog/README.md
@@ -1,6 +1,55 @@
 ## Notes
 <br/>
 
-Thanks to [Boris I. Bendovsky](https://github.com/bibendovsky/bstone) for creating this unofficial source port.  Also thanks to Cebion and romadu for the porting work for portmaster.
+Shareware version is included and ready to run. 
+
+To run the full version with all 6 episodes copy all *.BS6 files into 'ports/bstone-aog/gamedata/aliens_of_gold'.
+The Steam version of these files can be found by browsing local files and entering the 'Blake Stone - Aliens of Gold' directory.
+
+Thanks to [Boris I. Bendovsky](https://github.com/bibendovsky/bstone) for creating this unofficial source port.
+Also thanks to Cebion, Romadu, and Slayer366 for the porting work for portmaster.
 <br/>
 
+## Controls:
+<br/>
+
+## 2 Thumbsticks
+| Button | Action |
+|--|--| 
+|D-pad|Move/Turn|
+|L-Stick|Move/Strafe|
+|R-Stick|Turn|
+|Start|Enter/Make selection|
+|Select|Escape/Main Menu|
+|A/B|Make selection/Open doors/Interact|
+|X|Strafe|
+|Y|Y/Answer Yes to prompt(s)|
+|L1|Run|
+|R1|Shoot|
+|L3|Map|
+
+<br/>
+
+## No Thumbsticks
+| Button | Action |
+|--|--| 
+|D-pad|Move/Turn|
+|Start|Enter/Make selection|
+|Select|Escape/Main Menu|
+|A|Make selection/Open doors/Interact|
+|B|Map|
+|X|Run|
+|Y|Y/Answer Yes to prompt(s)|
+|L1|Strafe|
+|R1|Shoot|
+
+<br/>
+
+## Compile
+```shell
+sudo apt install -y cmake gcc clang libsdl2-dev libogg-dev libvorbis-dev libvorbisfile3 libvorbisenc2 libvorbisidec-dev
+git clone https://github.com/Slayer366/bstone
+cd bstone/build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j4
+```

--- a/ports/bstone-aog/port.json
+++ b/ports/bstone-aog/port.json
@@ -1,32 +1,49 @@
 {
-    "version": 2,
-    "name": "bstone-aog.zip",
-    "items": [
-        "Blake Stone - Aliens of Gold.sh",
-        "bstone-aog/"
+  "version": 4,
+  "name": "bstone-aog.zip",
+  "items": [
+    "Blake Stone - Aliens of Gold.sh",
+    "bstone-aog"
+  ],
+  "items_opt": [],
+  "attr": {
+    "title": "Blake Stone - Aliens of Gold",
+    "porter": [
+      "Cebion",
+      "romadu",
+      "Slayer366"
     ],
-    "items_opt": null,
-    "attr": {
-        "title": "Blake Stone Aliens of Gold",
-        "desc": "The unofficial source port for Blake Stone Aliens of Gold.",
-        "inst": "Includes the shareware files.  You can also add your own full version Blake Stone Aliens of Gold files to the ports/bstone-aog/gamedata/alien_of_gold folder.",
-        "genres": [
-            "fps",
-            "action"
-        ],
-        "porter": [
-            "Cebion",
-            "romadu",
-            "Slayer366"
-        ],
-        "image": {},
-        "rtr": true,
-        "runtime": null,
-        "reqs": [],
-        "arch": [
-            "aarch64",
-            "armhf",
-            "x86_64"
-        ]
-    }
+    "desc": "The unofficial source port for Blake Stone Aliens of Gold.",
+    "desc_md": null,
+    "inst": "Includes the shareware files.  You can also add your own full version Blake Stone - Aliens of Gold (*.BS6) files to the 'ports/bstone-aog/gamedata/aliens_of_gold' folder.  The Steam version of these files can be found by browsing local files and entering the 'Blake Stone - Aliens of Gold' directory.",
+    "inst_md": null,
+    "genres": [
+      "action",
+      "fps"
+    ],
+    "image": null,
+    "rtr": true,
+    "exp": false,
+    "runtime": [],
+    "store": [
+      {
+        "name": "Steam",
+        "gameurl": "https://store.steampowered.com/app/358190/Blake_Stone_Aliens_of_Gold/",
+        "developerurl": ""
+      },
+      {
+        "name": "GoG",
+        "gameurl": "https://www.gog.com/en/game/blake_stone_aliens_of_gold",
+        "developerurl": ""
+      }
+    ],
+    "availability": "demo",
+    "reqs": [],
+    "arch": [
+      "aarch64",
+      "armhf",
+      "x86_64"
+    ],
+    "min_glibc": ""
+  }
 }

--- a/ports/bstone-ps/Blake Stone - Planet Strike.sh
+++ b/ports/bstone-ps/Blake Stone - Planet Strike.sh
@@ -13,18 +13,17 @@ else
 fi
 
 source $controlfolder/control.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/bstone-ps"
 
-$ESUDO chmod 777 -R $GAMEDIR/*
-
-if [[ "${CFW_NAME^^}" == "MUOS" ]] || [[ "${CFW_NAME^^}" == "TRIMUI" ]]; then
-    sed -i 's/^\(vid_renderer\s*\)"[^"]*"/\1"software"/' "$GAMEDIR/conf/bibendovsky/bstone/bstone_config.txt"
-else
+if [[ "${CFW_NAME^^}" == *"ARKOS"* ]] || [[ "${CFW_NAME^^}" == "AMBERELEC" ]] || [[ "${CFW_NAME^^}" == "ROCKNIX" ]]; then
     sed -i 's/^\(vid_renderer\s*\)"[^"]*"/\1"gles_2_0"/' "$GAMEDIR/conf/bibendovsky/bstone/bstone_config.txt"
+elif [[ "${CFW_NAME^^}" == "RETRODECK" ]]; then
+    sed -i 's/^\(vid_renderer\s*\)"[^"]*"/\1"gl_2_0"/' "$GAMEDIR/conf/bibendovsky/bstone/bstone_config.txt"
+else
+    sed -i 's/^\(vid_renderer\s*\)"[^"]*"/\1"software"/' "$GAMEDIR/conf/bibendovsky/bstone/bstone_config.txt"
 fi
 
 cd $GAMEDIR
@@ -37,7 +36,9 @@ export DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-if [[ "$DEVICE_NAME" == "x55" ]] || [[ "$DEVICE_NAME" == "RG353P" ]] || [[ "$DEVICE_NAME" == "RG40XX-H" ]]; then
+$ESUDO chmod +x "$GAMEDIR/bstone.${DEVICE_ARCH}"
+
+if [[ "${DEVICE_NAME^^}" == "X55" ]] || [[ "${DEVICE_NAME^^}" == "RG353P" ]] || [[ "${DEVICE_NAME^^}" == "RG40XX-H" ]] || [[ "${CFW_NAME^^}" == "RETRODECK" ]]; then
     GPTOKEYB_CONFIG="$GAMEDIR/bstonetriggers.gptk"
 else
     GPTOKEYB_CONFIG="$GAMEDIR/bstone$ANALOG_STICKS.gptk"
@@ -45,6 +46,6 @@ fi
 
 $GPTOKEYB "bstone.${DEVICE_ARCH}" -c "$GPTOKEYB_CONFIG" &
 pm_platform_helper "$GAMEDIR/bstone.${DEVICE_ARCH}"
-./bstone.${DEVICE_ARCH} --vid_windowed_width $DISPLAY_WIDTH --vid_windowed_height $DISPLAY_HEIGHT --profile_dir $GAMEDIR/conf/bibendovsky/bstone --data_dir $GAMEDIR/gamedata/planet_strike $ADDLPARAMS
+./bstone.${DEVICE_ARCH} --vid_windowed_width $DISPLAY_WIDTH --vid_windowed_height $DISPLAY_HEIGHT --profile_dir $GAMEDIR/conf/bibendovsky/bstone --data_dir $GAMEDIR/gamedata/planet_strike
 
 pm_finish

--- a/ports/bstone-ps/README.md
+++ b/ports/bstone-ps/README.md
@@ -1,6 +1,55 @@
 ## Notes
 <br/>
 
-Thanks to [Boris I. Bendovsky](https://github.com/bibendovsky/bstone) for creating this unofficial source port.  Also thanks to Cebion and romadu for the porting work for portmaster.
+The full version is required to run Planet Strike.
+
+To run the full version copy all *.VSI files into 'ports/bstone-ps/gamedata/planet_strike'.
+The Steam version of these files can be found by browsing local files and entering the 'Blake Stone - Planet Strike' directory.
+
+Thanks to [Boris I. Bendovsky](https://github.com/bibendovsky/bstone) for creating this unofficial source port.
+Also thanks to Cebion, Romadu, and Slayer366 for the porting work for portmaster.
 <br/>
 
+## Controls:
+<br/>
+
+## 2 Thumbsticks
+| Button | Action |
+|--|--| 
+|D-pad|Move/Turn|
+|L-Stick|Move/Strafe|
+|R-Stick|Turn|
+|Start|Enter/Make selection|
+|Select|Escape/Main Menu|
+|A/B|Make selection/Open doors/Interact|
+|X|Strafe|
+|Y|Y/Answer Yes to prompt(s)|
+|L1|Run|
+|R1|Shoot|
+|L3|Map|
+
+<br/>
+
+## No Thumbsticks
+| Button | Action |
+|--|--| 
+|D-pad|Move/Turn|
+|Start|Enter/Make selection|
+|Select|Escape/Main Menu|
+|A|Make selection/Open doors/Interact|
+|B|Map|
+|X|Run|
+|Y|Y/Answer Yes to prompt(s)|
+|L1|Strafe|
+|R1|Shoot|
+
+<br/>
+
+## Compile
+```shell
+sudo apt install -y cmake gcc clang libsdl2-dev libogg-dev libvorbis-dev libvorbisfile3 libvorbisenc2 libvorbisidec-dev
+git clone https://github.com/Slayer366/bstone
+cd bstone/build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j4
+```

--- a/ports/bstone-ps/port.json
+++ b/ports/bstone-ps/port.json
@@ -1,31 +1,49 @@
 {
-    "version": 2,
-    "name": "bstone-ps.zip",
-    "items": [
-        "Blake Stone - Planet Strike.sh",
-        "bstone-ps/"
+  "version": 4,
+  "name": "bstone-ps.zip",
+  "items": [
+    "Blake Stone - Planet Strike.sh",
+    "bstone-ps"
+  ],
+  "items_opt": [],
+  "attr": {
+    "title": "Blake Stone - Planet Strike",
+    "porter": [
+      "Cebion",
+      "romadu",
+      "Slayer366"
     ],
-    "items_opt": null,
-    "attr": {
-        "title": "Blake Stone Planet Strike",
-        "desc": "The unofficial source port for Blake Stone Planet Strike.",
-        "inst": "You'll need to add your own full version Blake Stone Planet Strike files to the ports/bstone-ps/gamedata/planet_strike folder.",
-        "genres": [
-            "fps"
-        ],
-        "porter": [
-            "Cebion",
-            "romadu",
-            "Slayer366"
-        ],
-        "image": {},
-        "rtr": false,
-        "runtime": null,
-        "reqs": [],
-        "arch": [
-            "aarch64",
-            "armhf",
-            "x86_64"
-        ]
-    }
+    "desc": "The unofficial source port for Blake Stone Planet Strike.",
+    "desc_md": null,
+    "inst": "You'll need to add your own full version Blake Stone Planet Strike (*.VSI) files to the 'ports/bstone-ps/gamedata/planet_strike' folder.  The Steam version of these files can be found by browsing local files and entering the 'Blake Stone - Planet Strike' directory.",
+    "inst_md": null,
+    "genres": [
+      "action",
+      "fps"
+    ],
+    "image": null,
+    "rtr": false,
+    "exp": false,
+    "runtime": [],
+    "store": [
+      {
+        "name": "Steam",
+        "gameurl": "https://store.steampowered.com/app/358310/Blake_Stone_Planet_Strike/",
+        "developerurl": ""
+      },
+      {
+        "name": "GoG",
+        "gameurl": "https://www.gog.com/en/game/blake_stone_planet_strike",
+        "developerurl": ""
+      }
+    ],
+    "availability": "paid",
+    "reqs": [],
+    "arch": [
+      "aarch64",
+      "armhf",
+      "x86_64"
+    ],
+    "min_glibc": ""
+  }
 }


### PR DESCRIPTION
## Game Information
- **Update Port for**: Blake Stone - Aliens of Gold and Planet Strike

- Set video acceleration to be exclusive for only the variants that are known working with OpenGL and OpenGL ES rather than inclusive as new combinations of devices and CFWs (particularly ARM based) have issues with GLES breaking control input.  I also didn't want to set it to software mode for everything as having video acceleration improves performance on certain units and allows for graphical enhancements that aren't available in software mode.
- Add detection for RetroDeck in shell scripts to use OpenGL and bstonetriggers.gptk for controllers
- Update README to include controls and compile instructions
- Update port.json to v4, slightly revise instructions esp. for the Steam copy, and add Steam and GoG store links where Blake Stone can be purchased.