### PR TITLE
Update Serious Sam launch scripts

### DIFF
--- a/ports/serioussam-tfe/Serious Sam - The First Encounter.sh
+++ b/ports/serioussam-tfe/Serious Sam - The First Encounter.sh
@@ -13,31 +13,13 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
 export PORT_32BIT="Y"
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
-
 get_controls
 
-#GAMEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/sstfe"
 GAMEDIR="/$directory/ports/sstfe"
 
-if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
-    GPTOKEYB_CONFIG="$GAMEDIR/serioussamtriggers.gptk"  
-else
-    GPTOKEYB_CONFIG="$GAMEDIR/serioussam.gptk"
-fi
-
-$ESUDO chmod 777 $GAMEDIR/*
-
 cd $GAMEDIR
-
-> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
-
-$ESUDO chmod 666 /dev/tty0
-$ESUDO chmod 666 /dev/tty1
-$ESUDO chmod 666 /dev/uinput
 
 if [ -f "${controlfolder}/libgl_${CFW_NAME}.txt" ]; then 
   source "${controlfolder}/libgl_${CFW_NAME}.txt"
@@ -45,18 +27,29 @@ else
   source "${controlfolder}/libgl_default.txt"
 fi
 
+if [ "$LIBGL_FB" != "" ]; then
+  export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
+  export SDL_VIDEO_EGL_DRIVER="$GAMEDIR/gl4es/libEGL.so.1"
+  # Using lesser GL versions corrects rendering issues with Serious Sam Classic
+  export LIBGL_GL=14
+  export LIBGL_ES=1
+fi
+
+> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
+
 export LD_LIBRARY_PATH="$GAMEDIR/Bin/libs:/usr/lib32:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-if [ "$LIBGL_FB" != "" ]; then
-  export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
-  export LIBGL_GL=14
+$ESUDO chmod +x "$GAMEDIR/Bin/ssam-tfe"
+
+if [[ "${DEVICE_NAME^^}" == "X55" ]] || [[ "${DEVICE_NAME^^}" == "RG353P" ]] || [[ "${DEVICE_NAME^^}" == "RG40XX-H" ]]; then
+    GPTOKEYB_CONFIG="$GAMEDIR/serioussamtriggers.gptk"  
+else
+    GPTOKEYB_CONFIG="$GAMEDIR/serioussam.gptk"
 fi
 
 $GPTOKEYB "ssam-tfe" -c "$GPTOKEYB_CONFIG" &
+pm_platform_helper "$GAMEDIR/Bin/ssam-tfe"
 $GAMEDIR/Bin/ssam-tfe
 
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO systemctl restart oga_events &
-printf "\033c" > /dev/tty1
-printf "\033c" > /dev/tty0
+pm_finish

--- a/ports/serioussam-tse/Serious Sam - The Second Encounter.sh
+++ b/ports/serioussam-tse/Serious Sam - The Second Encounter.sh
@@ -13,31 +13,13 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
 export PORT_32BIT="Y"
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
-
 get_controls
 
-#GAMEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/sstse"
 GAMEDIR="/$directory/ports/sstse"
 
-if [[ "${DEVICE_NAME^^}" == 'X55' ]] || [[ "${DEVICE_NAME^^}" == 'RG353P' ]] || [[ "${DEVICE_NAME^^}" == 'RG40XX' ]]; then
-    GPTOKEYB_CONFIG="$GAMEDIR/serioussamtriggers.gptk"  
-else
-    GPTOKEYB_CONFIG="$GAMEDIR/serioussam.gptk"
-fi
-
-$ESUDO chmod 777 $GAMEDIR/*
-
 cd $GAMEDIR
-
-> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
-
-$ESUDO chmod 666 /dev/tty0
-$ESUDO chmod 666 /dev/tty1
-$ESUDO chmod 666 /dev/uinput
 
 if [ -f "${controlfolder}/libgl_${CFW_NAME}.txt" ]; then 
   source "${controlfolder}/libgl_${CFW_NAME}.txt"
@@ -45,18 +27,29 @@ else
   source "${controlfolder}/libgl_default.txt"
 fi
 
+if [ "$LIBGL_FB" != "" ]; then
+  export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
+  export SDL_VIDEO_EGL_DRIVER="$GAMEDIR/gl4es/libEGL.so.1"
+  # Using lesser GL versions corrects rendering issues with Serious Sam Classic
+  export LIBGL_GL=14
+  export LIBGL_ES=1
+fi
+
+> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
+
 export LD_LIBRARY_PATH="$GAMEDIR/Bin/libs:/usr/lib32:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
-if [ "$LIBGL_FB" != "" ]; then
-  export SDL_VIDEO_GL_DRIVER="$GAMEDIR/gl4es/libGL.so.1"
-  export LIBGL_GL=14
+$ESUDO chmod +x "$GAMEDIR/Bin/ssam-tse"
+
+if [[ "${DEVICE_NAME^^}" == "X55" ]] || [[ "${DEVICE_NAME^^}" == "RG353P" ]] || [[ "${DEVICE_NAME^^}" == "RG40XX-H" ]]; then
+    GPTOKEYB_CONFIG="$GAMEDIR/serioussamtriggers.gptk"  
+else
+    GPTOKEYB_CONFIG="$GAMEDIR/serioussam.gptk"
 fi
 
 $GPTOKEYB "ssam-tse" -c "$GPTOKEYB_CONFIG" &
+pm_platform_helper "$GAMEDIR/Bin/ssam-tse"
 $GAMEDIR/Bin/ssam-tse
 
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO systemctl restart oga_events &
-printf "\033c" > /dev/tty1
-printf "\033c" > /dev/tty0
+pm_finish


### PR DESCRIPTION
## Game Information
- **Update Port for**: Serious Sam Classic - both First and Second Encounter
Completely revised shell scripts for Serious Sam TFE & TSE
Updated how GL4ES gets initialized.  Serious Sam now renders lights and geometry correctly and works on all supporting CFWs!
While the first attempt worked on ArkOS and AmberELEC, this originally didn't work with muOS or ROCKNIX.  Now this configuration works across ALL the CFWs and Serious Sam doesn't look wierd with the lighting and no longer see meshes and world geometry that you aren't supposed to see.

I have re-tested with these new scripts on the following to ensure compatibility across firmwares:
RG351P/ArkOS
RG351P/AmberELEC
RG351P/ROCKNIX
RG34XX-SP/muOS
RG40XX-H/Knulli

### CFW Tests
- [x] ArkOS
- [x] AmberELEC
- [x] ROCKNIX
- [x] muOS
- [x] Knulli (Optional)

### Resolution Tests
- [x] 480x320 (Optional)
- [x] 640x480
- [x] 720x480 (RG34XX-SP)
