### PR TITLE
updated 7 retroarch port launch scripts to support upcoming Canada Goose muOS update

### DIFF
--- a/ports/2048/2048.sh
+++ b/ports/2048/2048.sh
@@ -13,8 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 if [[ $CFW_NAME == "TheRA" ]]; then
@@ -30,8 +29,10 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
   if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
     raconf="--config /run/muos/storage/info/config/retroarch.cfg"
-  else
+  elif [ -f /mnt/mmc/MUOS/retroarch/retroarch.cfg ]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  else
+    raconf=""
   fi
 elif [[ $CFW_NAME == "Miyoo" ]]; then
   raloc="/mnt/sdcard/RetroArch"
@@ -45,3 +46,4 @@ GAMEDIR="/$directory/ports/2048"
 
 $GPTOKEYB "retroarch" &
 $raloc/retroarch $raconf -L $GAMEDIR/2048_libretro.so.${DEVICE_ARCH}
+pm_finish

--- a/ports/cannonball-lr/Cannonball.sh
+++ b/ports/cannonball-lr/Cannonball.sh
@@ -13,8 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 if [[ $CFW_NAME == "TheRA" ]]; then
@@ -30,8 +29,10 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
   if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
     raconf="--config /run/muos/storage/info/config/retroarch.cfg"
-  else
+  elif [ -f /mnt/mmc/MUOS/retroarch/retroarch.cfg ]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  else
+    raconf=""
   fi
 elif [[ $CFW_NAME == "Miyoo" ]]; then
   raloc="/mnt/sdcard/RetroArch"
@@ -43,4 +44,6 @@ fi
 
 GAMEDIR="/$directory/ports/cannonball"
 
+$GPTOKEYB "retroarch" &
 $raloc/retroarch $raconf -L $GAMEDIR/cannonball_libretro.so $GAMEDIR/gamedata/epr-10187.88
+pm_finish

--- a/ports/cave.story/Cave Story.sh
+++ b/ports/cave.story/Cave Story.sh
@@ -13,8 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 if [[ $CFW_NAME == "TheRA" ]]; then
@@ -30,8 +29,10 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
   if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
     raconf="--config /run/muos/storage/info/config/retroarch.cfg"
-  else
+  elif [ -f /mnt/mmc/MUOS/retroarch/retroarch.cfg ]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  else
+    raconf=""
   fi
 elif [[ $CFW_NAME == "Miyoo" ]]; then
   raloc="/mnt/sdcard/RetroArch"
@@ -43,5 +44,6 @@ fi
 
 GAMEDIR="/$directory/ports/cavestory"
 
+$GPTOKEYB "retroarch" &
 $raloc/retroarch $raconf -L $GAMEDIR/nxengine_libretro.so $GAMEDIR/Doukutsu.exe
-
+pm_finish

--- a/ports/dinothawr/Dinothawr.sh
+++ b/ports/dinothawr/Dinothawr.sh
@@ -13,8 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 if [[ $CFW_NAME == "TheRA" ]]; then
@@ -30,8 +29,10 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
   if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
     raconf="--config /run/muos/storage/info/config/retroarch.cfg"
-  else
+  elif [ -f /mnt/mmc/MUOS/retroarch/retroarch.cfg ]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  else
+    raconf=""
   fi
 elif [[ $CFW_NAME == "Miyoo" ]]; then
   raloc="/mnt/sdcard/RetroArch"
@@ -43,5 +44,6 @@ fi
 
 GAMEDIR="/$directory/ports/dinothawr"
 
+$GPTOKEYB "retroarch" &
 $raloc/retroarch $raconf -L $GAMEDIR/dinothawr_libretro.so $GAMEDIR/dinothawr.game
-
+pm_finish

--- a/ports/mr.boom/Mr. Boom.sh
+++ b/ports/mr.boom/Mr. Boom.sh
@@ -13,8 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 if [[ $CFW_NAME == "TheRA" ]]; then
@@ -30,8 +29,10 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
   if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
     raconf="--config /run/muos/storage/info/config/retroarch.cfg"
-  else
+  elif [ -f /mnt/mmc/MUOS/retroarch/retroarch.cfg ]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  else
+    raconf=""
   fi
 elif [[ $CFW_NAME == "Miyoo" ]]; then
   raloc="/mnt/sdcard/RetroArch"
@@ -43,5 +44,6 @@ fi
 
 GAMEDIR="/$directory/ports/mrboom"
 
+$GPTOKEYB "retroarch" &
 $raloc/retroarch $raconf -L $GAMEDIR/mrboom_libretro.so
-
+pm_finish

--- a/ports/quake/Quake.sh
+++ b/ports/quake/Quake.sh
@@ -13,8 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 if [[ $CFW_NAME == "TheRA" ]]; then
@@ -30,8 +29,10 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
   if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
     raconf="--config /run/muos/storage/info/config/retroarch.cfg"
-  else
+  elif [ -f /mnt/mmc/MUOS/retroarch/retroarch.cfg ]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  else
+    raconf=""
   fi
 elif [[ $CFW_NAME == "Miyoo" ]]; then
   raloc="/mnt/sdcard/RetroArch"
@@ -45,3 +46,4 @@ GAMEDIR="/$directory/ports/quake"
 
 $GPTOKEYB "retroarch" &
 $raloc/retroarch $raconf -L $GAMEDIR/tyrquake_libretro.so $GAMEDIR/quakepaks/id1/*
+pm_finish

--- a/ports/rick.dangerous/Rick Dangerous.sh
+++ b/ports/rick.dangerous/Rick Dangerous.sh
@@ -13,8 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 if [[ $CFW_NAME == "TheRA" ]]; then
@@ -30,8 +29,10 @@ elif [[ $CFW_NAME == "muOS" ]]; then
   raloc="/usr/bin"
   if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
     raconf="--config /run/muos/storage/info/config/retroarch.cfg"
-  else
+  elif [ -f /mnt/mmc/MUOS/retroarch/retroarch.cfg ]; then
     raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
+  else
+    raconf=""
   fi
 elif [[ $CFW_NAME == "Miyoo" ]]; then
   raloc="/mnt/sdcard/RetroArch"
@@ -43,5 +44,6 @@ fi
 
 GAMEDIR="/$directory/ports/xrick"
 
+$GPTOKEYB "retroarch" &
 $raloc/retroarch $raconf -L $GAMEDIR/xrick_libretro.so $GAMEDIR
-
+pm_finish


### PR DESCRIPTION
Updating each of the following retroarch base port launch scripts for upcoming muOS update:
2048.sh	
Cannonball.sh
Cave Story.sh
Dinothawr.sh
Mr. Boom.sh
Quake.sh
Rick Dangerous.sh	

This edits the muOS block with the following elif/else portions:
elif [[ $CFW_NAME == "muOS" ]]; then
  raloc="/usr/bin"
  if [ -f /run/muos/storage/info/config/retroarch.cfg ]; then
    raconf="--config /run/muos/storage/info/config/retroarch.cfg"
  elif [ -f /mnt/mmc/MUOS/retroarch/retroarch.cfg ]; then
    raconf="--config /mnt/mmc/MUOS/retroarch/retroarch.cfg"
  else
    raconf=""
  fi

Additionally I updated each to use the standard script format with gptokeyb, pm_fishish and the mod_${CFW_NAME}.txt line

Each of these were not working on latest patch in muOS on rg35xxh and worked after, I also tested the change on a non-updated muOS install. 