### PR TITLE
Add a missing controlfolder line

### DIFF
--- a/ports/abombniball/Abombniball.sh
+++ b/ports/abombniball/Abombniball.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/abombniball/

--- a/ports/absolutereflex/Absolute Reflex.sh
+++ b/ports/absolutereflex/Absolute Reflex.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/absolutereflex"

--- a/ports/alchemyquest/Alchemy Quest.sh
+++ b/ports/alchemyquest/Alchemy Quest.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/alchemyquest/Open Alchemist.sh
+++ b/ports/alchemyquest/Open Alchemist.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/alienblaster/Alien Blaster.sh
+++ b/ports/alienblaster/Alien Blaster.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/alienblaster

--- a/ports/anarch/Anarch.sh
+++ b/ports/anarch/Anarch.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/anarch"

--- a/ports/anodyne/Anodyne.sh
+++ b/ports/anodyne/Anodyne.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 export ESUDO=$ESUDO

--- a/ports/apotris/Apotris.sh
+++ b/ports/apotris/Apotris.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/apotris

--- a/ports/apricots/Apricots.sh
+++ b/ports/apricots/Apricots.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 

--- a/ports/arkovstower/Arkovs Tower.sh
+++ b/ports/arkovstower/Arkovs Tower.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/arkovstower"

--- a/ports/augustus/Augustus.sh
+++ b/ports/augustus/Augustus.sh
@@ -18,6 +18,7 @@ if [ -z ${TASKSET+x} ]; then
 fi
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/avp/Alien vs Predator.sh
+++ b/ports/avp/Alien vs Predator.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/avp

--- a/ports/bbja/Blues Brothers Jukebox Adventure.sh
+++ b/ports/bbja/Blues Brothers Jukebox Adventure.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/jukeboxadventure"

--- a/ports/beat2x/Beat2x.sh
+++ b/ports/beat2x/Beat2x.sh
@@ -17,6 +17,7 @@ if [ -z ${TASKSET+x} ]; then
   source $controlfolder/tasksetter
 fi
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/bermuda_syndrome/Bermuda Syndrome.sh
+++ b/ports/bermuda_syndrome/Bermuda Syndrome.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/bermuda"

--- a/ports/blastius/Blastius.sh
+++ b/ports/blastius/Blastius.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/bleed/Bleed.sh
+++ b/ports/bleed/Bleed.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 gameassembly="Bleed.exe"

--- a/ports/bleed2/Bleed2.sh
+++ b/ports/bleed2/Bleed2.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 gameassembly="Bleed2.exe"

--- a/ports/blockdude_playdate/Blockdude Playdate.sh
+++ b/ports/blockdude_playdate/Blockdude Playdate.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/blockdude_playdate

--- a/ports/blossomtales2/Blossom Tales II.sh
+++ b/ports/blossomtales2/Blossom Tales II.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/blossomtales2"

--- a/ports/bluerevolver/BLUE REVOLVER.sh
+++ b/ports/bluerevolver/BLUE REVOLVER.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/bluerevolver"

--- a/ports/blues.brothers/Blues Brothers.sh
+++ b/ports/blues.brothers/Blues Brothers.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/bluesbrothers/"

--- a/ports/bowlingcross/Bowling Cross.sh
+++ b/ports/bowlingcross/Bowling Cross.sh
@@ -19,6 +19,7 @@ fi
 
 source $controlfolder/control.txt
 export PORT_32BIT="Y"
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 
 # We pull the controller configs from the get_controls function from the control.txt file here

--- a/ports/bravedogsroad/Brave Dogs Road.sh
+++ b/ports/bravedogsroad/Brave Dogs Road.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/brogue/Brogue.sh
+++ b/ports/brogue/Brogue.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/brogue/

--- a/ports/bugdom/Bugdom.sh
+++ b/ports/bugdom/Bugdom.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/bugdom"

--- a/ports/bumpersbroadswords/Bumpers & Broadswords.sh
+++ b/ports/bumpersbroadswords/Bumpers & Broadswords.sh
@@ -19,6 +19,7 @@ fi
 
 source $controlfolder/control.txt
 export PORT_32BIT="Y"
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 
 # We pull the controller configs from the get_controls function from the control.txt file here

--- a/ports/cannonball-st/Cannonball-st.sh
+++ b/ports/cannonball-st/Cannonball-st.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 exec > >(tee "$GAMEDIR/log.txt") 2>&1

--- a/ports/cardswithpersonalities/Cards with Personalities.sh
+++ b/ports/cardswithpersonalities/Cards with Personalities.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/cardswithpersonalities"

--- a/ports/cataclysm-dda/Cataclysm DDA.sh
+++ b/ports/cataclysm-dda/Cataclysm DDA.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/cataclysm-dda/

--- a/ports/cceleste/Celeste Classic.sh
+++ b/ports/cceleste/Celeste Classic.sh
@@ -17,6 +17,7 @@ if [ -z ${TASKSET+x} ]; then
   source $controlfolder/tasksetter
 fi
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/chessisstupid/Chess is Stupid.sh
+++ b/ports/chessisstupid/Chess is Stupid.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/cityglitch/cityglitch.sh
+++ b/ports/cityglitch/cityglitch.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/cityglitch"

--- a/ports/climb/Climb.sh
+++ b/ports/climb/Climb.sh
@@ -17,6 +17,7 @@ export PORT_32BIT="Y"
 
 [ -f "/etc/os-release" ] && source "/etc/os-release"
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty0

--- a/ports/colorlines/ColorLines.sh
+++ b/ports/colorlines/ColorLines.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/corsixth/CorsixTH.sh
+++ b/ports/corsixth/CorsixTH.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/CorsixTH"

--- a/ports/davegnukem/Dave Gnukem.sh
+++ b/ports/davegnukem/Dave Gnukem.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/deadicedeluxe/Dead Ice Deluxe.sh
+++ b/ports/deadicedeluxe/Dead Ice Deluxe.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/demonizer/Demonizer.sh
+++ b/ports/demonizer/Demonizer.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/demonizer

--- a/ports/demonizer/port.json
+++ b/ports/demonizer/port.json
@@ -15,7 +15,7 @@
         "inst": "You need to copy the game file (demonizer-demo.love or demonizer-full.love or demonizer demo.exe or ...) in gamedata directory and named it demonizer.love.",
         "genres": [
             "arcade",
-            "shmup"
+            "action"
         ],
         "image": null,
         "rtr": false,

--- a/ports/demonizer/port.json
+++ b/ports/demonizer/port.json
@@ -15,7 +15,7 @@
         "inst": "You need to copy the game file (demonizer-demo.love or demonizer-full.love or demonizer demo.exe or ...) in gamedata directory and named it demonizer.love.",
         "genres": [
             "arcade",
-            "shump"
+            "shmup"
         ],
         "image": null,
         "rtr": false,

--- a/ports/demonkeep/Demon Keep.sh
+++ b/ports/demonkeep/Demon Keep.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/demonkeep"

--- a/ports/depthsoflimbo/Depths of Limbo.sh
+++ b/ports/depthsoflimbo/Depths of Limbo.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/depthsoflimbo"

--- a/ports/derclou/Der Clou.sh
+++ b/ports/derclou/Der Clou.sh
@@ -17,6 +17,7 @@ if [ -z ${TASKSET+x} ]; then
   source $controlfolder/tasksetter
 fi
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/derclou

--- a/ports/dfencervstheorb/D-FENCER VS THE ORB.sh
+++ b/ports/dfencervstheorb/D-FENCER VS THE ORB.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/dfencervstheorb"

--- a/ports/doom3/Doom 3.sh
+++ b/ports/doom3/Doom 3.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 PORTS_DIR="/$directory/ports"

--- a/ports/drilbertiidiggeredoo/Drilbert II Diggeredoo.sh
+++ b/ports/drilbertiidiggeredoo/Drilbert II Diggeredoo.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/drilbertiidiggeredoo

--- a/ports/dungeoncrawlstonesoup/Dungeon Crawl Stone Soup.sh
+++ b/ports/dungeoncrawlstonesoup/Dungeon Crawl Stone Soup.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/dungeoncrawlstonesoup"

--- a/ports/dungeonrush/DungeonRush.sh
+++ b/ports/dungeonrush/DungeonRush.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/dungeonrush"

--- a/ports/dungeonsouls/Dungeon Souls.sh
+++ b/ports/dungeonsouls/Dungeon Souls.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/dynamate_playdate/Dynamate Playdate.sh
+++ b/ports/dynamate_playdate/Dynamate Playdate.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/dynamate_playdate

--- a/ports/endlessdungeon/Endless Dungeon.sh
+++ b/ports/endlessdungeon/Endless Dungeon.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/endlessdungeon"

--- a/ports/enigma/Enigma.sh
+++ b/ports/enigma/Enigma.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/escape/Escape.sh
+++ b/ports/escape/Escape.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/escape/

--- a/ports/exult/Exult-keyring.sh
+++ b/ports/exult/Exult-keyring.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/exult"

--- a/ports/exult/Exult-nokeyring.sh
+++ b/ports/exult/Exult-nokeyring.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/exult"

--- a/ports/f1race/F1 Race.sh
+++ b/ports/f1race/F1 Race.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/falling_time/Falling Time.sh
+++ b/ports/falling_time/Falling Time.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/falling_time

--- a/ports/fallout1/Fallout 1.sh
+++ b/ports/fallout1/Fallout 1.sh
@@ -30,6 +30,7 @@ to_lower_case() {
     done
 }
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 PORTDIR="/$directory/ports/fallout1"

--- a/ports/fallout2/Fallout 2.sh
+++ b/ports/fallout2/Fallout 2.sh
@@ -17,6 +17,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 PORTNAME="Fallout 2"

--- a/ports/fightorperish/Fight or Perish.sh
+++ b/ports/fightorperish/Fight or Perish.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/fightorperish

--- a/ports/finding_paradise/Finding Paradise.sh
+++ b/ports/finding_paradise/Finding Paradise.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/finding_paradise

--- a/ports/formula_1_playdate/Formula 1 Playdate.sh
+++ b/ports/formula_1_playdate/Formula 1 Playdate.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/formula_1_playdate

--- a/ports/freegemas/Freegemas.sh
+++ b/ports/freegemas/Freegemas.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/freeserf/FreeSerf.sh
+++ b/ports/freeserf/FreeSerf.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/freesynd/Freesynd.sh
+++ b/ports/freesynd/Freesynd.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/freesynd/

--- a/ports/fungusreaper/Fungus Reaper.sh
+++ b/ports/fungusreaper/Fungus Reaper.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/fungusreaper"

--- a/ports/galaxyforcesv2/Galaxy Forces 2.sh
+++ b/ports/galaxyforcesv2/Galaxy Forces 2.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/galaxyforcesv2

--- a/ports/gnurobbo/GNU Robbo.sh
+++ b/ports/gnurobbo/GNU Robbo.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/half-life/Half-Life.sh
+++ b/ports/half-life/Half-Life.sh
@@ -16,6 +16,7 @@ source $controlfolder/control.txt
 source $controlfolder/tasksetter
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 CUR_TTY=/dev/tty0
 

--- a/ports/hawkthorne/Hawkthorne.sh
+++ b/ports/hawkthorne/Hawkthorne.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/hawkthorne

--- a/ports/heart.of.darkness/Heart of Darkness.sh
+++ b/ports/heart.of.darkness/Heart of Darkness.sh
@@ -16,6 +16,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/hode

--- a/ports/heboris-sdl/Heboris-sdl.sh
+++ b/ports/heboris-sdl/Heboris-sdl.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/honeyguardian/Honey Guardian.sh
+++ b/ports/honeyguardian/Honey Guardian.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/honeyguardian"

--- a/ports/hota/Heart Of The Alien Redux.sh
+++ b/ports/hota/Heart Of The Alien Redux.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/hoverboard/xkcd Hoverboard.sh
+++ b/ports/hoverboard/xkcd Hoverboard.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/hunters/Hunters.sh
+++ b/ports/hunters/Hunters.sh
@@ -22,6 +22,7 @@ export PORT_32BIT="Y"
 
 
 # We pull the controller configs from the get_controls function from the control.txt file here
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty0

--- a/ports/inertiablast/Inertia Blast.sh
+++ b/ports/inertiablast/Inertia Blast.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/inertiablast

--- a/ports/infra_arcana/Infra Arcana.sh
+++ b/ports/infra_arcana/Infra Arcana.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/infra_arcana/

--- a/ports/invaders/Invaders.sh
+++ b/ports/invaders/Invaders.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/Invaders"

--- a/ports/jetsetwilly/Jet Set Willy.sh
+++ b/ports/jetsetwilly/Jet Set Willy.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/jetsetwilly

--- a/ports/jugglrx/JUGGLRX.sh
+++ b/ports/jugglrx/JUGGLRX.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/jugglrx"

--- a/ports/jumpnbump/Jump N Bump.sh
+++ b/ports/jumpnbump/Jump N Bump.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/jumpnbump

--- a/ports/kaima/Kaima.sh
+++ b/ports/kaima/Kaima.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/kaima

--- a/ports/kemonorogue/Kemono Rogue.sh
+++ b/ports/kemonorogue/Kemono Rogue.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/kemonorogue

--- a/ports/kenslabyrinth/Ken's Labyrinth.sh
+++ b/ports/kenslabyrinth/Ken's Labyrinth.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/kenslabyrinth"

--- a/ports/kingofmachines/King of Machines.sh
+++ b/ports/kingofmachines/King of Machines.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/klorets/Klorets.sh
+++ b/ports/klorets/Klorets.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/kobodeluxe/Kobo Deluxe.sh
+++ b/ports/kobodeluxe/Kobo Deluxe.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/laserkombat/Laser Kombat.sh
+++ b/ports/laserkombat/Laser Kombat.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/lbreakouthd/LBreakoutHD.sh
+++ b/ports/lbreakouthd/LBreakoutHD.sh
@@ -17,6 +17,7 @@ if [ -z ${TASKSET+x} ]; then
   source $controlfolder/tasksetter
 fi
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/lisathebashful/LISA The Bashful.sh
+++ b/ports/lisathebashful/LISA The Bashful.sh
@@ -16,6 +16,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/lisathebashful

--- a/ports/lisathehopeful/LISA The Hopeful.sh
+++ b/ports/lisathehopeful/LISA The Hopeful.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/lisathehopeful

--- a/ports/lisathejoyful/LISA The Joyful.sh
+++ b/ports/lisathejoyful/LISA The Joyful.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/lisathejoyful

--- a/ports/lisathepainful/LISA The Painful.sh
+++ b/ports/lisathepainful/LISA The Painful.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/lisathepainful

--- a/ports/lisathepointless/LISA The Pointless.sh
+++ b/ports/lisathepointless/LISA The Pointless.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/lisathepointless

--- a/ports/lisathetimeless/LISA The Timeless.sh
+++ b/ports/lisathetimeless/LISA The Timeless.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/lisathetimeless

--- a/ports/lisatheunbreakable/LISA The Unbreakable.sh
+++ b/ports/lisatheunbreakable/LISA The Unbreakable.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/lisatheunbreakable

--- a/ports/lisatheundone/LISA The Undone.sh
+++ b/ports/lisatheundone/LISA The Undone.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/lisatheundone

--- a/ports/lode/Lode.sh
+++ b/ports/lode/Lode.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/magicvigilante/Magic Vigilante.sh
+++ b/ports/magicvigilante/Magic Vigilante.sh
@@ -16,6 +16,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty0

--- a/ports/manicminer/Manic Miner.sh
+++ b/ports/manicminer/Manic Miner.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/manicminer

--- a/ports/meandmyshadow/Me and My Shadow.sh
+++ b/ports/meandmyshadow/Me and My Shadow.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/metanethunterg4/Metanet Hunter G4.sh
+++ b/ports/metanethunterg4/Metanet Hunter G4.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/metanethunterg4"

--- a/ports/mightymike/MightyMike.sh
+++ b/ports/mightymike/MightyMike.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/Abuse"

--- a/ports/minetest/Minetest.sh
+++ b/ports/minetest/Minetest.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/minetest"

--- a/ports/minit/Minit.sh
+++ b/ports/minit/Minit.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/missdriller/Miss Driller.sh
+++ b/ports/missdriller/Miss Driller.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/mojotron/Mojotron - Robot Wars.sh
+++ b/ports/mojotron/Mojotron - Robot Wars.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/mojotron

--- a/ports/moonlight/Moonlight.sh
+++ b/ports/moonlight/Moonlight.sh
@@ -71,6 +71,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/moonlight"

--- a/ports/multris/Multris.sh
+++ b/ports/multris/Multris.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/mutant_tank_knights/Mutant Tank Knights.sh
+++ b/ports/mutant_tank_knights/Mutant Tank Knights.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/mutant_tank_knights

--- a/ports/nanobounce/Nanobounce.sh
+++ b/ports/nanobounce/Nanobounce.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/nanobounce

--- a/ports/nanosaur/Nanosaur.sh
+++ b/ports/nanosaur/Nanosaur.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/nanosaur/

--- a/ports/nebulus/Nebulus.sh
+++ b/ports/nebulus/Nebulus.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/neogensokyo/Neo-Gensokyo.sh
+++ b/ports/neogensokyo/Neo-Gensokyo.sh
@@ -17,6 +17,7 @@ export PORT_32BIT="Y"
 
 [ -f "/etc/os-release" ] && source "/etc/os-release"
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty0

--- a/ports/ner/Ner.sh
+++ b/ports/ner/Ner.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/ner"

--- a/ports/neverball/Neverball.sh
+++ b/ports/neverball/Neverball.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/neverball/Neverputt.sh
+++ b/ports/neverball/Neverputt.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/nkaruga/nKaruga.sh
+++ b/ports/nkaruga/nKaruga.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty1

--- a/ports/nonny/Nonny.sh
+++ b/ports/nonny/Nonny.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/noparachute/No Parachute.sh
+++ b/ports/noparachute/No Parachute.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/noparachute"

--- a/ports/nothing/Nothing.sh
+++ b/ports/nothing/Nothing.sh
@@ -17,6 +17,7 @@ if [ -z ${TASKSET+x} ]; then
   source $controlfolder/tasksetter
 fi
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/npuzzle/NPuzzle.sh
+++ b/ports/npuzzle/NPuzzle.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/oddworld/Oddworld Abes Exoddus.sh
+++ b/ports/oddworld/Oddworld Abes Exoddus.sh
@@ -18,6 +18,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/relive"

--- a/ports/oddworld/Oddworld Abes Oddysee.sh
+++ b/ports/oddworld/Oddworld Abes Oddysee.sh
@@ -18,6 +18,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/relive"

--- a/ports/openblok/OpenBlok.sh
+++ b/ports/openblok/OpenBlok.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/openclaw/Openclaw.sh
+++ b/ports/openclaw/Openclaw.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/openclaw"

--- a/ports/openfodder/OpenFodder.sh
+++ b/ports/openfodder/OpenFodder.sh
@@ -17,6 +17,7 @@ if [ -z ${TASKSET+x} ]; then
   source $controlfolder/tasksetter
 fi
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/openggs/Open Great Giana Sisters.sh
+++ b/ports/openggs/Open Great Giana Sisters.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/openmrac/Openmrac.sh
+++ b/ports/openmrac/Openmrac.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/openmrac

--- a/ports/opensupaplex/OpenSupaplex.sh
+++ b/ports/opensupaplex/OpenSupaplex.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 CUR_TTY=/dev/tty0

--- a/ports/opensyobon/OpenSyobon.sh
+++ b/ports/opensyobon/OpenSyobon.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/oquonie/Oquonie.sh
+++ b/ports/oquonie/Oquonie.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/oquonie/

--- a/ports/osanasrevenge/Osana's Revenge.sh
+++ b/ports/osanasrevenge/Osana's Revenge.sh
@@ -9,6 +9,7 @@ else
   controlfolder="/roms/ports/PortMaster"
 fi
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 # Set variables

--- a/ports/owlboy/Owlboy.sh
+++ b/ports/owlboy/Owlboy.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/owlboy"

--- a/ports/pacman/Pacman.sh
+++ b/ports/pacman/Pacman.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/pacman"

--- a/ports/panzerpaladin/PanzerPaladin.sh
+++ b/ports/panzerpaladin/PanzerPaladin.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 export ESUDO=$ESUDO

--- a/ports/pekka-kana-2/Pekka Kana 2.sh
+++ b/ports/pekka-kana-2/Pekka Kana 2.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/pekka-kana-2

--- a/ports/plumberssdl/Plumbers Don't Wear Ties.sh
+++ b/ports/plumberssdl/Plumbers Don't Wear Ties.sh
@@ -10,6 +10,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/plumberssdl

--- a/ports/pocketwondersport/Pocket Wonder Sport.sh
+++ b/ports/pocketwondersport/Pocket Wonder Sport.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/powder/Powder.sh
+++ b/ports/powder/Powder.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/powder

--- a/ports/powerlevel/Power Level.sh
+++ b/ports/powerlevel/Power Level.sh
@@ -16,6 +16,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 [ -f "/etc/os-release" ] && source "/etc/os-release"

--- a/ports/prehistorik.2/Prehistorik 2.sh
+++ b/ports/prehistorik.2/Prehistorik 2.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/prehistorik2"

--- a/ports/profadeluxe/Abu Simbel Profanation Deluxe.sh
+++ b/ports/profadeluxe/Abu Simbel Profanation Deluxe.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/profadeluxe

--- a/ports/psebay/Psebay.sh
+++ b/ports/psebay/Psebay.sh
@@ -17,6 +17,7 @@ export PORT_32BIT="Y"
 
 [ -f "/etc/os-release" ] && source "/etc/os-release"
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty0

--- a/ports/puremetal/Puremetal.sh
+++ b/ports/puremetal/Puremetal.sh
@@ -17,6 +17,7 @@ export PORT_32BIT="Y"
 
 [ -f "/etc/os-release" ] && source "/etc/os-release"
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty0

--- a/ports/putridshotultra/Putrid Shot Ultra.sh
+++ b/ports/putridshotultra/Putrid Shot Ultra.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/putridshotultra"

--- a/ports/puztrix_playdate/Puztrix Playdate.sh
+++ b/ports/puztrix_playdate/Puztrix Playdate.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/puztrix_playdate

--- a/ports/rakuen/Rakuen.sh
+++ b/ports/rakuen/Rakuen.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/rakuen

--- a/ports/raptor/Raptor.sh
+++ b/ports/raptor/Raptor.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/rebound/Rebound.sh
+++ b/ports/rebound/Rebound.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/rebound

--- a/ports/redtrees/Red Trees.sh
+++ b/ports/redtrees/Red Trees.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/redtrees

--- a/ports/reminiscence/REminiscence.sh
+++ b/ports/reminiscence/REminiscence.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/reminiscence"

--- a/ports/retrotime/Retro Time.sh
+++ b/ports/retrotime/Retro Time.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/ri_li/Ri-Li.sh
+++ b/ports/ri_li/Ri-Li.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/ri_li

--- a/ports/rigelengine/RigelEngine.sh
+++ b/ports/rigelengine/RigelEngine.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/RigelEngine"

--- a/ports/rlone/Rlone.sh
+++ b/ports/rlone/Rlone.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/rlone/

--- a/ports/rotationalshift/Rotational Shift.sh
+++ b/ports/rotationalshift/Rotational Shift.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/russiansubwaydogs/Russian Subway Dogs.sh
+++ b/ports/russiansubwaydogs/Russian Subway Dogs.sh
@@ -17,6 +17,7 @@ export PORT_32BIT="Y"
 
 [ -f "/etc/os-release" ] && source "/etc/os-release"
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty0

--- a/ports/rvgl/RVGL.sh
+++ b/ports/rvgl/RVGL.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/rvgl

--- a/ports/sdlsopwith/SDL Sopwith.sh
+++ b/ports/sdlsopwith/SDL Sopwith.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/sevenkingdoms/Seven Kingdoms - Ancient Adversaries.sh
+++ b/ports/sevenkingdoms/Seven Kingdoms - Ancient Adversaries.sh
@@ -14,6 +14,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/sevenkingdoms

--- a/ports/shadow.warrior/Shadow Warrior.sh
+++ b/ports/shadow.warrior/Shadow Warrior.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/shadow-warrior"

--- a/ports/shipwreck/Shipwreck.sh
+++ b/ports/shipwreck/Shipwreck.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 export ESUDO=$ESUDO

--- a/ports/simplesokoban/Simple Sokoban.sh
+++ b/ports/simplesokoban/Simple Sokoban.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/skijump3/Skijump3.sh
+++ b/ports/skijump3/Skijump3.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/skijump3"

--- a/ports/snaklipse/Snaklipse.sh
+++ b/ports/snaklipse/Snaklipse.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/sneakr/SneakR.sh
+++ b/ports/sneakr/SneakR.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/sneggpit/Sneggpit.sh
+++ b/ports/sneggpit/Sneggpit.sh
@@ -16,6 +16,7 @@ fi
 # We source the control.txt file contents here
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/sneggpit"

--- a/ports/snkrx/SNKRX.sh
+++ b/ports/snkrx/SNKRX.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/snkrx"

--- a/ports/spectralslash/Spectral Slash.sh
+++ b/ports/spectralslash/Spectral Slash.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/spectralslash"

--- a/ports/spellsling/Spell Sling.sh
+++ b/ports/spellsling/Spell Sling.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/spellsling"

--- a/ports/spelltower/Spell Tower.sh
+++ b/ports/spelltower/Spell Tower.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/spelltower"

--- a/ports/spelltower/port.json
+++ b/ports/spelltower/port.json
@@ -15,7 +15,7 @@
     "inst": "Download the game https://youdoyoubuddy.itch.io/spell-tower and copy the exe or love file into the port folder.",
     "genres": [
       "rpg",
-	  "card"
+	  "casino/card"
     ],
     "image": null,
     "rtr": false,

--- a/ports/srb2/SRB2.sh
+++ b/ports/srb2/SRB2.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/SRB2/

--- a/ports/srb2kart/Sonic Robo Blast 2 Kart.sh
+++ b/ports/srb2kart/Sonic Robo Blast 2 Kart.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/srb2kart

--- a/ports/stardewvalley/StardewValley.sh
+++ b/ports/stardewvalley/StardewValley.sh
@@ -16,6 +16,7 @@ source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 source $controlfolder/tasksetter
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 gamedir="/$directory/ports/stardewvalley"

--- a/ports/starvsthegame/Star vs the Game.sh
+++ b/ports/starvsthegame/Star vs the Game.sh
@@ -21,6 +21,7 @@ source $controlfolder/control.txt
 export PORT_32BIT="Y"
 
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 # We pull the controller configs from the get_controls function from the control.txt file here
 get_controls
 

--- a/ports/steelassault/SteelAssault.sh
+++ b/ports/steelassault/SteelAssault.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/steelassault"

--- a/ports/strangeadventures/Strange Adventures in Infinte Space.sh
+++ b/ports/strangeadventures/Strange Adventures in Infinte Space.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/strangeadventures

--- a/ports/sunsetwitchclassic/Sunset_Witch_Classic.sh
+++ b/ports/sunsetwitchclassic/Sunset_Witch_Classic.sh
@@ -15,7 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 export PORT_32BIT="Y" # game is gameloader, armhf, but 7za used is 64bit for 
-[ -f "${controlfolder}/mod${CFWNAME}.txt" ] && source "${controlfolder}/mod${CFWNAME}.txt"
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty0

--- a/ports/superrobotninjagirl/Super Robot Ninja Girl.sh
+++ b/ports/superrobotninjagirl/Super Robot Ninja Girl.sh
@@ -22,6 +22,7 @@ export PORT_32BIT="Y"
 
 
 # We pull the controller configs from the get_controls function from the control.txt file here
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty0

--- a/ports/supertux/SuperTux.sh
+++ b/ports/supertux/SuperTux.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/supertux

--- a/ports/supertuxkart/SuperTuxKart.sh
+++ b/ports/supertuxkart/SuperTuxKart.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/switchfin/Switchfin.sh
+++ b/ports/switchfin/Switchfin.sh
@@ -12,6 +12,7 @@ else
   controlfolder="/roms/ports/PortMaster"
 fi
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 # Adjust these to your paths

--- a/ports/tamatool/Tamatool.sh
+++ b/ports/tamatool/Tamatool.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/tamatool"

--- a/ports/thermomorph/Thermomorph.sh
+++ b/ports/thermomorph/Thermomorph.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/thermomorph

--- a/ports/tinystg/TinySTG.sh
+++ b/ports/tinystg/TinySTG.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/tinystg

--- a/ports/tmntsr/TMNTShreddersRevenge.sh
+++ b/ports/tmntsr/TMNTShreddersRevenge.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 export ESUDO=$ESUDO

--- a/ports/to_the_moon/To the Moon.sh
+++ b/ports/to_the_moon/To the Moon.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/to_the_moon"

--- a/ports/towerfall/TowerFall Ascension.sh
+++ b/ports/towerfall/TowerFall Ascension.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/tasksetter
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 gameassembly="TowerFall.exe"

--- a/ports/tube64/tube64.sh
+++ b/ports/tube64/tube64.sh
@@ -17,6 +17,7 @@ if [ -z ${TASKSET+x} ]; then
   source $controlfolder/tasksetter
 fi
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/twodie/Two Die.sh
+++ b/ports/twodie/Two Die.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR="/$directory/ports/twodie"

--- a/ports/udlrmodify/UDLR_Modify.sh
+++ b/ports/udlrmodify/UDLR_Modify.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 export PORT_32BIT="N"
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/udlrmodify/

--- a/ports/ultimatetapankaikki/Ultimatetapankaikki.sh
+++ b/ports/ultimatetapankaikki/Ultimatetapankaikki.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/ultimatetapankaikki

--- a/ports/upo/Upo.sh
+++ b/ports/upo/Upo.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/upo

--- a/ports/uqm/UQM.sh
+++ b/ports/uqm/UQM.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/UQM

--- a/ports/valhalla/Valhalla.sh
+++ b/ports/valhalla/Valhalla.sh
@@ -17,6 +17,7 @@ export PORT_32BIT="Y"
 
 [ -f "/etc/os-release" ] && source "/etc/os-release"
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty0

--- a/ports/vanillara/VanillaRA.sh
+++ b/ports/vanillara/VanillaRA.sh
@@ -17,6 +17,7 @@ source $controlfolder/device_info.txt
 
 DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/vanillatd/VanillaTD.sh
+++ b/ports/vanillatd/VanillaTD.sh
@@ -17,6 +17,7 @@ source $controlfolder/device_info.txt
 
 DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/vcmi/VCMI.sh
+++ b/ports/vcmi/VCMI.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/waternet/Waternet.sh
+++ b/ports/waternet/Waternet.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/wetspot2/Wetspot2.sh
+++ b/ports/wetspot2/Wetspot2.sh
@@ -14,6 +14,7 @@ fi
 
 source $controlfolder/control.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 GAMEDIR=/$directory/ports/wetspot2

--- a/ports/wordlesdl/Wordle SDL.sh
+++ b/ports/wordlesdl/Wordle SDL.sh
@@ -17,6 +17,7 @@ if [ -z ${TASKSET+x} ]; then
   source $controlfolder/tasksetter
 fi
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/xenonvalkyrie/Xenon Valkyrie.sh
+++ b/ports/xenonvalkyrie/Xenon Valkyrie.sh
@@ -17,6 +17,7 @@ export PORT_32BIT="Y"
 
 [ -f "/etc/os-release" ] && source "/etc/os-release"
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 $ESUDO chmod 666 /dev/tty0

--- a/ports/yatka/yatka.sh
+++ b/ports/yatka/yatka.sh
@@ -15,6 +15,7 @@ fi
 source $controlfolder/control.txt
 source $controlfolder/device_info.txt
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/zgloom/ZGloom.sh
+++ b/ports/zgloom/ZGloom.sh
@@ -13,6 +13,7 @@ else
 fi
 
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/znax/Znax.sh
+++ b/ports/znax/Znax.sh
@@ -17,6 +17,7 @@ if [ -z ${TASKSET+x} ]; then
   source $controlfolder/tasksetter
 fi
 
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 ## TODO: Change to PortMaster/tty when Johnnyonflame merges the changes in,

--- a/ports/zniwadventure/Zniw Adventure.sh
+++ b/ports/zniwadventure/Zniw Adventure.sh
@@ -12,6 +12,7 @@ else
   controlfolder="/roms/ports/PortMaster"
 fi
 source $controlfolder/control.txt
+[ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
 # Adjust these to your paths


### PR DESCRIPTION
Adds a missing [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt" to all scripts that miss it. Fixes audio for many ports on Knulli.
