### PR TITLE
Update Pacman.sh

### DIFF
--- a/ports/pacman/Pacman.sh
+++ b/ports/pacman/Pacman.sh
@@ -13,8 +13,6 @@ else
 fi
 
 source $controlfolder/control.txt
-source $controlfolder/device_info.txt
-
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 
@@ -22,23 +20,16 @@ GAMEDIR="/$directory/ports/pacman"
 
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
-[ ! -f "$GAMEDIR/port_cfg" ] && cp -f "$GAMEDIR/port_cfg.template" "$GAMEDIR/port_cfg"
-
-$ESUDO chmod 777 -R $GAMEDIR/*
+$ESUDO chmod +x "$GAMEDIR/pacman.${DEVICE_ARCH}"
 
 cd $GAMEDIR
-
-$ESUDO chmod 666 /dev/tty0
-$ESUDO chmod 666 /dev/tty1
 
 export DEVICE_ARCH="${DEVICE_ARCH:-aarch64}"
 export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 $GPTOKEYB "pacman.${DEVICE_ARCH}" -c "$GAMEDIR/pacman.gptk" &
+pm_platform_helper "$GAMEDIR/pacman.${DEVICE_ARCH}"
 ./pacman.${DEVICE_ARCH}
 
-$ESUDO kill -9 $(pidof gptokeyb)
-$ESUDO systemctl restart oga_events &
-printf "\033c" > /dev/tty1
-printf "\033c" > /dev/tty0
+pm_finish


### PR DESCRIPTION
## Game Information
- **Update shell script for**: Pacman

After looking over the scripts that Ganimoth added the missing controlfolder lines to, Pacman.sh was one of them and it was here that I noticed that my Pacman.sh needed some much needed attention.

- No longer need to call device_info.txt since control.txt now does this for us (nothing new lol)
- Removed check-&-copy port_cfg.template as this was remnant from using a copy of my Tile World shell script (whoops. pfft.)
- Changed setting full perms on entire folder to only ensuring the executable has execute permissions
- Removed chmod /dev/tty# lines since control.txt now does this for us, too
- Add pm_platform_helper line
- Clean up end of script to use pm_finish

Thanks to Ganimoth spotting my missing custom CFW controlfolder line I probably wouldn't have realized just how poor a state I'd left this in lol