### PR TITLE
World of Goo - fix clean install from GOG asset

### DIFF
--- a/ports/worldofgoo/World of Goo.sh
+++ b/ports/worldofgoo/World of Goo.sh
@@ -68,7 +68,7 @@ export TEXTINPUTINTERACTIVE="Y"
 WOG_FILE=$(ls *.sh 2> /dev/null | head -n 1)
 
 if [ -f "$WOG_FILE" ]; then
-    unzip -o "$WOG_FILE" > "$CUR_TTY"
+    unzip -o "$WOG_FILE"
     # Handle game directory movement based on structure
     if [ -d "data/noarch/game/game" ]; then
         $ESUDO mv -f data/noarch/game/game "$GAMEDIR/gamedata/"

--- a/ports/worldofgoo/World of Goo.sh
+++ b/ports/worldofgoo/World of Goo.sh
@@ -68,6 +68,7 @@ export TEXTINPUTINTERACTIVE="Y"
 WOG_FILE=$(ls *.sh 2> /dev/null | head -n 1)
 
 if [ -f "$WOG_FILE" ]; then
+    pm_message "Extracting Game files, please wait. This could take a while"
     unzip -o "$WOG_FILE"
     # Handle game directory movement based on structure
     if [ -d "data/noarch/game/game" ]; then


### PR DESCRIPTION
Remove leftover variable reference

## Game Information
- **Update Port for**: World of Goo
  Remove output redirect that causes asset extraction to fail 

### CFW Tests
- [x] ROCKNIX

### Resolution Tests
- [x] Higher resolutions (1680x1050)