### PR TITLE
update chasm docs to only reference GOG and automatically extract

### DIFF
--- a/ports/chasm/Chasm.sh
+++ b/ports/chasm/Chasm.sh
@@ -39,10 +39,17 @@ bind_directories ~/.local/share/Chasm "$gamedir/savedata"
 # unpack the installer if it exists
 chasm_gog_installer=$(ls chasm_*.sh 2>/dev/null | head -n 1)
 if [ -n "$chasm_gog_installer" ]; then
-    unzip "$chasm_gog_installer"
-    cp -r data/noarch/game/* .
-    # clean up only the extracted script and installer files
-    rm -rf "$chasm_gog_installer" data meta scripts
+    if [ -f "$controlfolder/utils/patcher.txt" ]; then
+        export ESUDO
+        export PATCHER_FILE="$GAMEDIR/tools/patchscript"
+        export PATCHER_GAME="$(basename "${0%.*}")"
+        export PATCHER_TIME="2 to 5 minutes"
+        export controlfolder
+        source "$controlfolder/utils/patcher.txt"
+        $ESUDO kill -9 $(pidof gptokeyb)
+    else
+        echo "This port requires the latest version of PortMaster."
+    fi
 fi
 
 # Remove all the dependencies in favour of system libs - e.g. the included 
@@ -58,6 +65,37 @@ export PATH="$monodir/bin":"$PATH"
 # Configure the renderpath
 export FNA3D_FORCE_DRIVER=OpenGL
 export FNA3D_OPENGL_FORCE_ES3=1
+
+# special case alsa hack for arkos
+if [ "${HOME}" = "/home/ark" ]; then
+    export SDL_AUDIODRIVER=alsa
+    export AUDIODEV=default
+
+    if [ ! -f "${HOME}/.asoundrc" ]; then
+        cat > "${HOME}/.asoundrc" <<'EOF'
+pcm.!default {
+  type plug
+  slave.pcm "dmixer"
+}
+
+pcm.dmixer {
+  type dmix
+  ipc_key 1024
+  slave.pcm "hw:0,0"
+  slave.rate 44100
+  slave.period_size 1024
+  slave.buffer_size 4096
+  bindings.0 0
+  bindings.1 1
+}
+
+ctl.!default {
+  type hw
+  card 0
+}
+EOF
+    fi
+fi
 
 $GPTOKEYB "mono" &
 $TASKSET mono $gameassembly 2>&1 | tee "$gamedir/log.txt" /dev/tty0

--- a/ports/chasm/Chasm.sh
+++ b/ports/chasm/Chasm.sh
@@ -36,6 +36,15 @@ $ESUDO mount "$monofile" "$monodir"
 # Setup savedir
 bind_directories ~/.local/share/Chasm "$gamedir/savedata"
 
+# unpack the installer if it exists
+chasm_gog_installer=$(ls chasm_*.sh 2>/dev/null | head -n 1)
+if [ -n "$chasm_gog_installer" ]; then
+    unzip "$chasm_gog_installer"
+    cp -r data/noarch/game/* .
+    # clean up only the extracted script and installer files
+    rm -rf "$chasm_gog_installer" data meta scripts
+fi
+
 # Remove all the dependencies in favour of system libs - e.g. the included 
 # newer version of FNA with patcher included
 rm -f System*.dll mscorlib.dll FNA.dll Mono.*.dll

--- a/ports/chasm/README.md
+++ b/ports/chasm/README.md
@@ -1,22 +1,13 @@
 ## Notes
 
-* Download the Linux build of Chasm from your favorite platform, such as GOG, Steam or Humble:
-* [Steam](https://store.steampowered.com/app/312200/Chasm/) (windows, etc):
-				* Copy the following URL on your browser: steam://open/console
-				* Run the following command on the console: download_depot 312200 312202
-				* Find the assets on the path reported by the console when the download is finished.
+* Only the GOG version of Chasm is known to work with this port.  All
+  current Steam versions have been encumbered with DRM.
+* MAKE SURE YOU HAVE THE LATEST VERSION OF THIS PORT AND THE
+  PORTMASTER APP
 * [GOG](https://www.gog.com/game/chasm):
 				* Download the Linux build of the game on the website.
-				* Rename the .sh file (e.g. chasm_1_084_61001.sh) to .gzip (e.g. chasm_1_084_61001.gzip)
-				* Extract the file with your favorite utility (such as 7zip, unzip, etc.).
-				* Find the assets on chasm_1_084_61001\data\noarch\game\
-* [Humble](https://www.humblebundle.com/store/chasm):
-				* Pending (I don't have a humble copy 🤷)
-* Copy all of the Linux build files, such as Chasm.exe and all of the accompanying files to chasm/gamedata
+				* Place .sh file (e.g. `chasm_1_093_78208.sh`) in chasm/gamedata
 * Enjoy.
-
-
-
 
 Thanks for the the [FNA Project](https://github.com/FNA-XNA/FNA) for the amazing cross-platform, portable implementation of XNA.
 Thanks to the [Bit Kid](https://bitkidgames.com/) folks for the amazing game and patience.

--- a/ports/chasm/README.md
+++ b/ports/chasm/README.md
@@ -1,12 +1,17 @@
 ## Notes
 
-* Only the GOG version of Chasm is known to work with this port.  All
-  current Steam versions have been encumbered with DRM.
 * MAKE SURE YOU HAVE THE LATEST VERSION OF THIS PORT AND THE
   PORTMASTER APP
 * [GOG](https://www.gog.com/game/chasm):
 				* Download the Linux build of the game on the website.
-				* Place .sh file (e.g. `chasm_1_093_78208.sh`) in chasm/gamedata
+				* Place .sh file (e.g. `chasm_1_093_78208.sh`) in
+                  chasm/gamedata
+* [Steam](https://store.steampowered.com/app/312200/Chasm/). Open
+  steam console via Windows+R: Type: steam://open/console, download
+  the latest version by typing: `download_depot 312200 312202
+  6524806414975889296` in the console. When the download is complete,
+  it will tell you the location of the folder. Transfer all the game
+  files to ports/chasm/gamedata
 * Enjoy.
 
 Thanks for the the [FNA Project](https://github.com/FNA-XNA/FNA) for the amazing cross-platform, portable implementation of XNA.

--- a/ports/chasm/chasm/tools/patchscript
+++ b/ports/chasm/chasm/tools/patchscript
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# unpack the installer if it exists
+chasm_gog_installer=$(ls chasm_*.sh 2>/dev/null | head -n 1)
+if [ -n "$chasm_gog_installer" ]; then
+    unzip "$chasm_gog_installer"
+    cp -r data/noarch/game/* .
+    # clean up only the extracted script and installer files
+    rm -rf "$chasm_gog_installer" data meta scripts
+fi

--- a/ports/chasm/port.json
+++ b/ports/chasm/port.json
@@ -13,6 +13,7 @@
         ],
         "desc": "Explore the depths below a remote mountain town in this procedurally-generated Adventure Platformer. Taking inspiration from hack 'n slash dungeon crawlers and Metroidvania-style platformers, Chasm will immerse you in a fantasy world full of exciting treasure, deadly enemies, and abundant secrets.",
         "inst": "Copy the game's assets to the 'chasm/gamedata/' folder.",
+        "inst_md": "Purchase the game from GOG and place the install script in ports/chasm/gamedata.  Optionally, purchase the game from [Steam](https://store.steampowered.com/app/312200/Chasm/). Open steam console via Windows+R: Type: steam://open/console, download the latest version by typing: `download_depot 312200 312202 6524806414975889296` in the console. When the download is complete, it will tell you the location of the folder. Transfer all the game files to ports/chasm/gamedata",
         "genres": [
             "action",
             "adventure",


### PR DESCRIPTION
Small fix to chasm docs and installer to reduce friction for users