### PR TITLE
Update port.json for Steamworld Dig since box32 reqs armhf

### DIFF
--- a/ports/steamworlddig/port.json
+++ b/ports/steamworlddig/port.json
@@ -32,7 +32,9 @@
       }
     ],
     "availability": "paid",
-    "reqs": [],
+    "reqs": [
+      "armhf"
+    ],
     "arch": [
       "armhf"
     ],


### PR DESCRIPTION
used device a roo https://kloptops.github.io/device-a-roo/ to ensure reqs for armhf work properly to prevent this from showing on trimui devices after westonpack became a runtime which ignores the arch requirement.

Issue highlighted from: https://discord.com/channels/1122861252088172575/1421177198718484540



