### PR TITLE
Update port.json for Friends of Ringo

### DIFF
--- a/ports/friendsofringo/port.json
+++ b/ports/friendsofringo/port.json
@@ -23,6 +23,7 @@
     "rtr": false,
     "exp": false,
     "runtime": [
+      "dotnet-8.0.12.squashfs",
       "gmtoolkit.squashfs"
     ],
     "store": [


### PR DESCRIPTION
Adding the missing runtime requirement as I can see poeple constantly sending help requests with the dotnet runtime missing.
