### PR TITLE
Fix typo when trying to add to LD_LIBRARY_PATH

### DIFF
--- a/ports/plague/Plague.sh
+++ b/ports/plague/Plague.sh
@@ -23,7 +23,7 @@ $ESUDO chmod 666 /dev/tty0
 
 GAMEDIR="/$directory/ports/plague"
 
-export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/libs:$LD_IBRARY_PATH"
+export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/libs:$LD_LIBRARY_PATH"
 export GMLOADER_DEPTH_DISABLE=1
 export GMLOADER_SAVEDIR="$GAMEDIR/gamedata/"
 export GMLOADER_PLATFORM="os_linux"


### PR DESCRIPTION
Don't have the needed devices to test on but noticed this typo was preventing loading on the miyoo flip since its overriding the current LD_LIBRARY_PATH rather than prepending to it. Confirmed the game still loads afterwards on muOS on the RG34xxSP

## Submission Requirements

### CFW Tests
Ensure your game has been tested on all major CFWs:
- [ ] ArkOS
- [ ] AmberELEC
- [ ] ROCKNIX
- [x] muOS
- [ ] Knulli (Optional)
- [ ] Crossmix (Optional)
- [ ] Other (add here)

### Resolution Tests
Test all major resolutions:
- [ ] 480x320 (Optional)
- [ ] 640x480
- [ ] 720x720 (RGB30) (Optional)
- [ ] Higher resolutions (e.g., 1280x720)

## File Structure
- Your port should have the following structure:
  - portname/
    - port.json
    - README.md
    - screenshot.png
    - cover.png
    - gameinfo.xml
    - Port Name.sh
    - portname/
      - <portfiles here>

## Additional Resources
For an in-depth guide on creating a pull request, refer to: [PortMaster Game Packaging Guide](https://portmaster.games/packaging.html#creating-a-pull-request)
