### PR TITLE
Update NiceChess - fix board rendering on some devices

### DIFF
--- a/ports/nicechess/NiceChess.sh
+++ b/ports/nicechess/NiceChess.sh
@@ -32,6 +32,7 @@ if [ "$LIBGL_FB" != "" ] && [ "${CFW_NAME^^}" != "KNULLI" ]; then
 fi
 
 [ "$DEVICE_CPU" == "RK3326" ] && export LIBGL_ES=1
+[ "${DEVICE_CPU^^}" == "H700" ] && [ "${CFW_NAME^^}" == "MUOS" ] && export LIBGL_ES=1
 
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 


### PR DESCRIPTION
## Game Information
- **Update Port for**: NiceChess

Some RK3326 devices would show solid black squares regardless the CFW (ROCKNIX being the exception)
Setting LIBGL_ES=1 works wonderfully across the board with RK3326 and all CFWs.  ROCKNIX has no issues rendering NiceChess regardless the settings, but LIBGL_ES=1 fixes black or green squares on RK3326 whether it be ArkOS or AmberELEC.  I'm only doing this for RK3326 and H700 devices running muOS.
Knulli will be opted out with this fix as it resulted in a plain white screen.  In other words; Knulli hated this.
This should be a worthy workaround for now until one day I find a much better solution which may involve some serious modification to the source code.
At least for now, the only device that suffers the most is the RGB30 with its 720x720 display.  You can still play the game, but it just looks ugly.
With this, at least the game will render correctly on more devices than those that don't, and some that don't still have an aesthetically pleasing chess board even if the blue texture doesn't draw so it's inconsequential in the other places I cannot currently fix it.

### CFW Tests
- [x] ArkOS
- [x] AmberELEC
- [x] ROCKNIX

### Resolution Tests
- [x] 480x320 (Optional)
- [x] 640x480
