### PR TITLE
Adding txt file to Flip Clock for future use

### DIFF
--- a/ports/flipclock/flipclock/mux_launch.txt
+++ b/ports/flipclock/flipclock/mux_launch.txt
@@ -1,0 +1,29 @@
+#!/bin/bash
+# HELP: PortMaster
+# ICON: portmaster
+# GRID: PortMaster
+
+. /opt/muos/script/var/func.sh
+
+echo app >/tmp/act_go
+
+GOV_GO="/tmp/gov_go"
+[ -e "$GOV_GO" ] && cat "$GOV_GO" >"$(GET_VAR "device" "cpu/governor")"
+
+
+SETUP_SDL_ENVIRONMENT
+
+HOME="$(GET_VAR "device" "board/home")"
+export HOME
+
+SET_VAR "system" "foreground_process" "portmaster"
+
+# Get the script's basename without the path
+APP_PATH=$(dirname "$0")
+APP_NAME=$(basename "$APP_PATH")
+PM_SCRIPT_DIR="/mnt/union/ROMS/ports"
+
+"${PM_SCRIPT_DIR}/${APP_NAME}.sh"
+
+
+unset SDL_ASSERT SDL_HQ_SCALER SDL_ROTATION SDL_BLITTER_DISABLED


### PR DESCRIPTION
I am working on a potential update to allow installing apps like this one for muOS.

This mux_launch.txt file can be copied with some additional platform specific code for portmaster installs (currently in testing/development), but will have no impact to other systems. 