### PR TITLE
STEAMWORLD DIG/HEIST added 32bit export

### DIFF
--- a/ports/steamworlddig/Steamworld Dig.sh
+++ b/ports/steamworlddig/Steamworld Dig.sh
@@ -12,6 +12,7 @@ else
   controlfolder="/roms/ports/PortMaster"
 fi
 source $controlfolder/control.txt 
+export PORT_32BIT="Y"
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 

--- a/ports/steamworldheist/Steamworld Heist.sh
+++ b/ports/steamworldheist/Steamworld Heist.sh
@@ -11,7 +11,8 @@ elif [ -d "$XDG_DATA_HOME/PortMaster/" ]; then
 else
   controlfolder="/roms/ports/PortMaster"
 fi
-source $controlfolder/control.txt 
+source $controlfolder/control.txt
+export PORT_32BIT="Y"
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 get_controls
 


### PR DESCRIPTION
Just needed the 'export 32_BIT="Y" 'line added to the .sh's of these and audio is working now on MuOS. Steamworld Dig 2 does not have this export but audio seems to work still for some reason.
