### PR TITLE
Hotfix for Bot Vice patchscript

### DIFF
--- a/ports/botvice/botvice/tools/patchscript
+++ b/ports/botvice/botvice/tools/patchscript
@@ -39,12 +39,12 @@ apply_xdeltas() {
     
         # Checksum for the Itch version
         if [ "$checksum" = "6b142ac0c2ee8f420536c0b6e3a4dd57" ]; then
-            $ESUDO xdelta3 -d -s $DATADIR/game.unx -f $TOOLDIR/patch/botviceitch.xdelta $DATADIR/game.droid && \
+            $controlfolder/xdelta3 -d -s $DATADIR/game.unx -f $TOOLDIR/patch/botviceitch.xdelta $DATADIR/game.droid && \
             rm $DATADIR/game.unx
             echo "Itch.io game.unx has been patched"
         # Checksum for the Steam version
         elif [ "$checksum" = "3fe30a5ad65b690df8695c1d19f9735b" ]; then
-            $ESUDO xdelta3 -d -s $DATADIR/game.unx -f $TOOLDIR/patch/botvicesteam.xdelta $DATADIR/game.droid && \
+            $controlfolder/xdelta3 -d -s $DATADIR/game.unx -f $TOOLDIR/patch/botvicesteam.xdelta $DATADIR/game.droid && \
             rm $DATADIR/game.unx
  	        echo "Steam game.unx has been patched"
         else
@@ -61,7 +61,7 @@ apply_xdeltas() {
     
         # Checksum for the Itch.io audiogroup1.dat version
         if [ "$checksum" = "2ff52611327de50e195e3043f6b88969" ]; then
-            $ESUDO xdelta3 -d -s $DATADIR/audiogroup1.dat -f $TOOLDIR/patch/audiogroup1.xdelta $DATADIR/audiogroup1patched.dat && \
+            $controlfolder/xdelta3 -d -s $DATADIR/audiogroup1.dat -f $TOOLDIR/patch/audiogroup1.xdelta $DATADIR/audiogroup1patched.dat && \
             rm $DATADIR/audiogroup1.dat
             mv $DATADIR/audiogroup1patched.dat $DATADIR/audiogroup1.dat
             echo "Itch.io audiogroup1.dat has been patched."
@@ -76,7 +76,7 @@ apply_xdeltas() {
     
         # Checksum for the Itch.io audiogroup2.dat version
         if [ "$checksum" = "6c9f8c441e9ef3f32f099ef2fe583f75" ]; then
-            $ESUDO xdelta3 -d -s $DATADIR/audiogroup2.dat -f $TOOLDIR/patch/audiogroup2.xdelta $DATADIR/audiogroup2patched.dat && \
+            $controlfolder/xdelta3 -d -s $DATADIR/audiogroup2.dat -f $TOOLDIR/patch/audiogroup2.xdelta $DATADIR/audiogroup2patched.dat && \
             rm $DATADIR/audiogroup2.dat
             mv $DATADIR/audiogroup2patched.dat $DATADIR/audiogroup2.dat
             echo "Itch.io audiogroup2.dat has been patched."


### PR DESCRIPTION
Bot Vice is missing the xdelta3 binary, causing it to fail patching. Replacing it with the one included with PM

