### PR TITLE
Update architecture from 'armhf' to 'aarch64'

### DIFF
--- a/ports/forager/port.json
+++ b/ports/forager/port.json
@@ -24,7 +24,7 @@
       "power"
     ],
     "arch": [
-      "armhf"
+      "aarch64"
     ]
   }
 }


### PR DESCRIPTION
🐕

# WOOF