### PR TITLE
Update 3 ports' swap creation to work with dArkOS

### DIFF
--- a/ports/duke3dawo/Duke3D - Alien World Order.sh
+++ b/ports/duke3dawo/Duke3D - Alien World Order.sh
@@ -45,13 +45,23 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 # Ensure Swap space is prepared or eduke32 may crash or fail to launch
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     pm_message "Preparing Swap File, please wait..."
-    [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-    [ -f /swapfile ] && $ESUDO rm -f /swapfile
-    $ESUDO fallocate -l 384M /swapfile
-    $ESUDO chmod 600 /swapfile
-    $ESUDO mkswap /swapfile
-    $ESUDO swapon /swapfile
-    [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
+    if [[ $CFW_NAME == "dArkOS" ]]; then
+        [ -e /dev/zram0 ] && $ESUDO swapoff -a
+        [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+        [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+        [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+        modprobe zram
+        $ESUDO zramctl --find --size 384M
+        $ESUDO mkswap /dev/zram0
+        $ESUDO swapon /dev/zram0
+    else
+        [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+        [ -f /swapfile ] && $ESUDO rm -f /swapfile
+        $ESUDO fallocate -l 384M /swapfile
+        $ESUDO chmod 600 /swapfile
+        $ESUDO mkswap /swapfile
+        $ESUDO swapon /swapfile
+    fi
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
     pm_message "Preparing Swap File, please wait..."
     [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
@@ -60,7 +70,6 @@ elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
     $ESUDO chmod 600 /media/SHARE/swapfile
     $ESUDO mkswap /media/SHARE/swapfile
     $ESUDO swapon /media/SHARE/swapfile
-    [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 fi
 
 if [[ "${DEVICE_NAME^^}" == "X55" ]] || [[ "${DEVICE_NAME^^}" == "RG353P" ]] || [[ "${DEVICE_NAME^^}" == "RG40XX-H" ]] || [[ "${CFW_NAME^^}" == "RETRODECK" ]]; then

--- a/ports/ionfury/Ion Fury.sh
+++ b/ports/ionfury/Ion Fury.sh
@@ -40,13 +40,23 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 # Ensure Swap space is prepared or eduke32 may crash or fail to launch
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     pm_message "Preparing Swap File, please wait..."
-    [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-    [ -f /swapfile ] && $ESUDO rm -f /swapfile
-    $ESUDO fallocate -l 384M /swapfile
-    $ESUDO chmod 600 /swapfile
-    $ESUDO mkswap /swapfile
-    $ESUDO swapon /swapfile
-    [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
+    if [[ $CFW_NAME == "dArkOS" ]]; then
+        [ -e /dev/zram0 ] && $ESUDO swapoff -a
+        [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+        [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+        [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+        modprobe zram
+        $ESUDO zramctl --find --size 384M
+        $ESUDO mkswap /dev/zram0
+        $ESUDO swapon /dev/zram0
+    else
+        [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+        [ -f /swapfile ] && $ESUDO rm -f /swapfile
+        $ESUDO fallocate -l 384M /swapfile
+        $ESUDO chmod 600 /swapfile
+        $ESUDO mkswap /swapfile
+        $ESUDO swapon /swapfile
+    fi
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
     pm_message "Preparing Swap File, please wait..."
     [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
@@ -55,7 +65,6 @@ elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
     $ESUDO chmod 600 /media/SHARE/swapfile
     $ESUDO mkswap /media/SHARE/swapfile
     $ESUDO swapon /media/SHARE/swapfile
-    [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 fi
 
 if [[ "${DEVICE_NAME^^}" == "X55" ]] || [[ "${DEVICE_NAME^^}" == "RG353P" ]] || [[ "${DEVICE_NAME^^}" == "RG40XX-H" ]]; then

--- a/ports/rott/Rise of the Triad - Dark War.sh
+++ b/ports/rott/Rise of the Triad - Dark War.sh
@@ -30,12 +30,23 @@ export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     pm_message "Preparing Swap File, please wait..."
-    [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-    [ -f /swapfile ] && $ESUDO rm -f /swapfile
-    $ESUDO fallocate -l 384M /swapfile
-    $ESUDO chmod 600 /swapfile
-    $ESUDO mkswap /swapfile
-    $ESUDO swapon /swapfile
+    if [[ $CFW_NAME == "dArkOS" ]]; then
+        [ -e /dev/zram0 ] && $ESUDO swapoff -a
+        [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+        [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+        [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+        modprobe zram
+        $ESUDO zramctl --find --size 384M
+        $ESUDO mkswap /dev/zram0
+        $ESUDO swapon /dev/zram0
+    else
+        [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+        [ -f /swapfile ] && $ESUDO rm -f /swapfile
+        $ESUDO fallocate -l 384M /swapfile
+        $ESUDO chmod 600 /swapfile
+        $ESUDO mkswap /swapfile
+        $ESUDO swapon /swapfile
+    fi
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
     pm_message "Preparing Swap File, please wait..."

--- a/ports/rott/Rise of the Triad - The Hunt Begins.sh
+++ b/ports/rott/Rise of the Triad - The Hunt Begins.sh
@@ -30,12 +30,23 @@ export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     pm_message "Preparing Swap File, please wait..."
-    [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-    [ -f /swapfile ] && $ESUDO rm -f /swapfile
-    $ESUDO fallocate -l 384M /swapfile
-    $ESUDO chmod 600 /swapfile
-    $ESUDO mkswap /swapfile
-    $ESUDO swapon /swapfile
+    if [[ $CFW_NAME == "dArkOS" ]]; then
+        [ -e /dev/zram0 ] && $ESUDO swapoff -a
+        [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+        [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+        [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+        modprobe zram
+        $ESUDO zramctl --find --size 384M
+        $ESUDO mkswap /dev/zram0
+        $ESUDO swapon /dev/zram0
+    else
+        [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+        [ -f /swapfile ] && $ESUDO rm -f /swapfile
+        $ESUDO fallocate -l 384M /swapfile
+        $ESUDO chmod 600 /swapfile
+        $ESUDO mkswap /swapfile
+        $ESUDO swapon /swapfile
+    fi
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
     pm_message "Preparing Swap File, please wait..."


### PR DESCRIPTION
## Game Information
- **Update Port for**: Duke Nukem 3D: Alien World Order
- **Update Port for**: Ion Fury
- **Update Port for**: Rise of the Triad

eduke32 absolutely will not launch without an existing swap.
Added dArkOS detection and create swap using zram for dArkOS (swapfile is not possible with btrfs & kernel 4.19)
Re-tested on both ArkOS and dArkOS to ensure proper swap gets created per CFW after swap block addition.

### CFW Tests
- [x] ArkOS
- [x] dArkOS


NOTE: Open Transport Tycoon Deluxe may or may not require the same update to its shell script.