### PR TITLE
Commander Genius - Add x86_64 architecture to port.json 

### DIFF
--- a/ports/commander.genius/port.json
+++ b/ports/commander.genius/port.json
@@ -28,7 +28,8 @@
         "runtime": null,
         "reqs": [],
         "arch": [
-            "aarch64"
+            "aarch64",
+            "x86_64"
         ]
     }
 }


### PR DESCRIPTION
Port already tested on Steam deck, but json was not updated:
https://github.com/PortsMaster/PortMaster-New/pull/1772