### PR TITLE
Ensure executable permissions for gmloadernext.aarch64

### DIFF
--- a/ports/gravitystorm/Gravity Storm - First Mission.sh
+++ b/ports/gravitystorm/Gravity Storm - First Mission.sh
@@ -26,6 +26,9 @@ GMLOADER_JSON="$GAMEDIR/gmloader.json"
 cd $GAMEDIR
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
+# Ensure executable permissions
+$ESUDO chmod +x "$GAMEDIR/gmloadernext.aarch64"
+
 # Exports
 export LD_LIBRARY_PATH="$GAMEDIR/lib:$LD_LIBRARY_PATH"
 


### PR DESCRIPTION
Required fix for some Rocknix versions if not installed via autoinstall
(used this port as a base for Triple Swap Tower)