### PR TITLE
2048: add Knulli CFW support

### DIFF
--- a/ports/2048/2048.sh
+++ b/ports/2048/2048.sh
@@ -37,6 +37,13 @@ elif [[ $CFW_NAME == "muOS" ]]; then
 elif [[ $CFW_NAME == "Miyoo" ]]; then
   raloc="/mnt/sdcard/RetroArch"
   raconf=""
+elif [[ $CFW_NAME == "knulli" ]]; then
+  raloc="/usr/bin"
+  if [ -f /userdata/system/configs/retroarch/retroarchcustom.cfg ]; then
+    raconf="--config /userdata/system/configs/retroarch/retroarchcustom.cfg"
+  else
+    raconf=""
+  fi
 else
   raloc="/usr/bin"
   raconf=""


### PR DESCRIPTION
Add Knulli to the CFW detection chain with the correct RetroArch location and config path. I don't know anything about that RetroArch config but it seems to work for me like this.