### PR TITLE
Fix Chasm GOG version installation

### DIFF
--- a/ports/chasm/Chasm.sh
+++ b/ports/chasm/Chasm.sh
@@ -41,7 +41,7 @@ chasm_gog_installer=$(ls chasm_*.sh 2>/dev/null | head -n 1)
 if [ -n "$chasm_gog_installer" ]; then
     if [ -f "$controlfolder/utils/patcher.txt" ]; then
         export ESUDO
-        export PATCHER_FILE="$GAMEDIR/tools/patchscript"
+        export PATCHER_FILE="$gamedir/tools/patchscript"
         export PATCHER_GAME="$(basename "${0%.*}")"
         export PATCHER_TIME="2 to 5 minutes"
         export controlfolder

--- a/ports/chasm/chasm/tools/patchscript
+++ b/ports/chasm/chasm/tools/patchscript
@@ -3,7 +3,7 @@
 # unpack the installer if it exists
 chasm_gog_installer=$(ls chasm_*.sh 2>/dev/null | head -n 1)
 if [ -n "$chasm_gog_installer" ]; then
-    "$controlfolder/7zzs.$DEVICE_ARCH" x "$chasm_gog_installer"
+    "$controlfolder/7zzs.$DEVICE_ARCH" x "$chasm_gog_installer" -tzip
     cp -r data/noarch/game/* .
     # clean up only the extracted script and installer files
     rm -rf "$chasm_gog_installer" data meta scripts


### PR DESCRIPTION
1. Fix upper case typo (GAMEDIR vs gamedir)
2. Explicitly tell 7zip to treat archive as a zip as it fails to autodetect the type producing one binary blob instead of folder tree with the following error:
```
ERROR: There are some data after the end of the payload data
```

My setup:
Anbernic RG40XX-H
KNULLI Gladiator II
PortMaster PM: 2026.04.01-1426, HM: 2025-06-06
GOG installer chasm_1_109_90014.sh