### PR TITLE
Correct Pyxel 2.4.6 runtime name

### DIFF
--- a/runtimes/runtimes.json
+++ b/runtimes/runtimes.json
@@ -231,7 +231,7 @@
         }
     },
     "pyxel_2.4.6_python_3.11.squashfs": {
-        "name": "Pyxel 2.3.18",
+        "name": "Pyxel 2.4.6",
         "default": "aarch64",
         "arch": {
             "aarch64": "pyxel_2.4.6_python_3.11_aarch64.squashfs",


### PR DESCRIPTION
Made the following correction:
```
    "pyxel_2.3.18_python_3.11.squashfs": {
        "name": "Pyxel 2.3.18",
        ...
    },
    "pyxel_2.4.6_python_3.11.squashfs": {
        "name": "Pyxel 2.4.6", <-------------- WAS 2.3.18
        ...
```

Only one game uses this runtime (Dragon vs hunters), and it runs with either (I tested). So this shouldn't cause any issues.

https://github.com/PortsMaster/PortMaster-New/blob/08bfa422a057459af3b5989271ecaeed14b34e01/ports/dragonvshunters/port.json