### PR TITLE
Fix: PuzzleScript muOS

### DIFF
--- a/ports/puzzlescriptpm/PuzzleScript PM.sh
+++ b/ports/puzzlescriptpm/PuzzleScript PM.sh
@@ -24,15 +24,15 @@ CONFDIR="$GAMEDIR/conf/"
 # cd & permissions
 cd "$GAMEDIR"
 
-# extract node binary on first run (a quick task, so no need for pm_message)
+# extract node binary on first run
 if [ ! -f "$GAMEDIR/node" ]; then
-  echo "Extracting node binary ..."
+  pm_message "Extracting node binary ..."
   if "$controlfolder/7zzs.$DEVICE_ARCH" x "$GAMEDIR/node.7z" -o"$GAMEDIR" -y; then
-    echo "Extraction successful."
+    pm_message "Extraction successful."
     chmod +x "$GAMEDIR/node"
     rm -f "$GAMEDIR/node.7z"
   else
-    echo "Extraction failed!"
+    pm_message "Extraction failed!"
     pm_finish
     exit 1
   fi

--- a/ports/puzzlescriptpm/puzzlescriptpm/pruntime-node/main.js
+++ b/ports/puzzlescriptpm/puzzlescriptpm/pruntime-node/main.js
@@ -69,6 +69,8 @@ if (process.env.SDL2FB === '1') {
     process.stderr.write('Error: cannot open /dev/fb0\n');
     process.exit(1);
   }
+  // Reset framebuffer pan to page 0 (fixes blank screen on double-buffered fb)
+  try { fs.writeFileSync('/sys/class/graphics/fb0/pan', '0,0'); } catch(e) {}
 }
 
 // open input devices


### PR DESCRIPTION
Port will occasionally display a blank screen on muOS. This will fix it.  
(Also replaced `echo` with `pm_message`)