### PR TITLE
quake (libretro): fixed controls on Knulli

### DIFF
--- a/ports/quake/Quake.sh
+++ b/ports/quake/Quake.sh
@@ -37,6 +37,13 @@ elif [[ $CFW_NAME == "muOS" ]]; then
 elif [[ $CFW_NAME == "Miyoo" ]]; then
   raloc="/mnt/sdcard/RetroArch"
   raconf=""
+elif [[ $CFW_NAME == "knulli" ]]; then
+  raloc="/usr/bin"
+  if [ -f /userdata/system/configs/retroarch/retroarchcustom.cfg ]; then
+    raconf="--config /userdata/system/configs/retroarch/retroarchcustom.cfg"
+  else
+    raconf=""
+  fi
 else
   raloc="/usr/bin"
   raconf=""


### PR DESCRIPTION
Fixed broken controls on Knulli.

This same issue had been discussed long ago—see [here, on the Knulli discord server](https://discord.com/channels/1173228527605272666/1227616479818813553/1317604699582627951), for one example—but it seems a generic fix was never implemented, and 2048 (another libretro port) [recently implemented a fix identical to this one](https://github.com/PortsMaster/PortMaster-New/pull/2388).

Feel free to disregard if this is not the preferred way to fix this.