### PR TITLE
necrodancer: fix King Konga boss battle

### DIFF
--- a/ports/necrodancer/Crypt of the NecroDancer.sh
+++ b/ports/necrodancer/Crypt of the NecroDancer.sh
@@ -158,8 +158,8 @@ cat > "$GAMEDIR/conf/userconfig.json" <<USERCONFIG
 	"wos": {
 		"game": {
 			"graphics": {
-				"textureAtlasSize": 1024,
-				"textureLayerCount": 2
+				"textureAtlasSize": 1728,
+				"textureLayerCount": 1
 			},
 			"window": {
 				"size": [${DISPLAY_WIDTH:-640}, ${DISPLAY_HEIGHT:-480}],


### PR DESCRIPTION
In order to save RAM I had resized the texture atlas of the game from 4096x4096 to 1024x1024.
However, there's one sprite sheet in the King Konga boss fight that's 1728 pixels wide that doesn't fit in the game's dynamic atlas with this sizing, so instead we resize the atlas to 1728x1728 and now it fits.  This adds ten or so megs of ram usage but we have margins.

Tested on a few of my local devices (and it's a small change)