### PR TITLE
Fix Wolfenstein 3D engines for dArkOS

### DIFF
--- a/ports/wolf3d/Wolfenstein 3D.sh
+++ b/ports/wolf3d/Wolfenstein 3D.sh
@@ -48,8 +48,16 @@ sed -i "s/^FullScreenWidth = [0-9]\+/FullScreenWidth = $DISPLAY_WIDTH/" "$CONFIG
 
 # CD and set permissions
 cd $GAMEDIR
-exec > "$GAMEDIR/log.txt" 2>&1
+> "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 $ESUDO chmod +xwr -R $GAMEDIR/*
+
+# libfreetype.so.6 version conflict fix for some devices running ArkOS and/or dArkOS
+if [[ "${CFW_NAME^^}" == *"DARKOS"* ]]; then
+    if [ -f "$GAMEDIR/libs/libfreetype.so.6" ]; then
+        $ESUDO rm -f "$GAMEDIR/libs/libfreetype.so.6"
+        sleep 0.5
+    fi
+fi
 
 # Exports
 export LD_LIBRARY_PATH="$GAMEDIR/libs:$LD_LIBRARY_PATH"

--- a/ports/wolf3d/Wolfenstein 3D.sh
+++ b/ports/wolf3d/Wolfenstein 3D.sh
@@ -51,7 +51,7 @@ cd $GAMEDIR
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 $ESUDO chmod +xwr -R $GAMEDIR/*
 
-# libfreetype.so.6 version conflict fix for some devices running ArkOS and/or dArkOS
+# libfreetype version conflict fix for devices running dArkOS
 if [[ "${CFW_NAME^^}" == *"DARKOS"* ]]; then
     if [ -f "$GAMEDIR/libs/libfreetype.so.6" ]; then
         $ESUDO rm -f "$GAMEDIR/libs/libfreetype.so.6"


### PR DESCRIPTION
## Game Information
- **Update Port for**: Wolfenstein 3D Engines

The provided libfreetype.so.6 lib prevented the love launcher from starting on dArkOS.
Tested and confirmed crash on dArkOS-RE on R36S clone.
Added check to delete bundled libfreetype.so.6 if running dArkOS
Re-tested working on same device with updated shell script.

### CFW Tests
- [x] dArkOS
