### PR TITLE
Flip Clock muOS mux_launch.txt update for upcoming Andromeda release

### DIFF
--- a/ports/flipclock/flipclock/mux_launch.txt
+++ b/ports/flipclock/flipclock/mux_launch.txt
@@ -21,7 +21,11 @@ SET_VAR "system" "foreground_process" "portmaster"
 # Get the script's basename without the path
 APP_PATH=$(dirname "$0")
 APP_NAME=$(basename "$APP_PATH")
-PM_SCRIPT_DIR="/mnt/union/ROMS/ports"
+PM_SCRIPT_DIR="/mnt/mmc/ROMS/ports"
+
+if [ ! -f "${PM_SCRIPT_DIR}/${APP_NAME}.sh" ]; then
+  PM_SCRIPT_DIR="/mnt/sdcard/ROMS/ports"
+fi
 
 "${PM_SCRIPT_DIR}/${APP_NAME}.sh"
 


### PR DESCRIPTION
/mnt/union is going away in the next release of muOS 

Updated PM_SCRIPT_DIR to point to the correct directory for scripts. Added a conditional check for the existence of the script in mmc or sdcard directories.
