### PR TITLE
Support Steam via download depot

### DIFF
--- a/ports/binkystrashservice/port.json
+++ b/ports/binkystrashservice/port.json
@@ -13,8 +13,8 @@
     ],
     "desc": "Storm evil lairs ... and take out the trash! Play as BINKY in a perilous, precision platformer where you run a garbage collection service for EVIL LAIRS! Optimise your speedrun strats and empty all the trash in 15 unique and colourful mini-Metroidvania maps!",
     "desc_md": null,
-    "inst": "Purchase the game from itch.io (https://ondydev.itch.io/binkys-trash-service). Download, extract, and copy the game files to the binkystrashservice/assets directory.",
-    "inst_md": "Purchase the game from [itch.io](https://ondydev.itch.io/binkys-trash-service). Download, extract, and copy the game files to the `binkystrashservice/assets` directory.",
+    "inst": "Purchase the game from itch.io (https://ondydev.itch.io/binkys-trash-service) or Steam (https://store.steampowered.com/app/1498940/Binkys_Trash_Service/). For Steam, use the console and enter download_depot 1498940 1498941 7126354185184625380. Download, extract, and copy the game files to the binkystrashservice/assets directory.",
+    "inst_md": "Purchase the game from [itch.io](https://ondydev.itch.io/binkys-trash-service) or [Steam](https://store.steampowered.com/app/1498940/Binkys_Trash_Service/). For Steam, open the [console](steam://open/console) and enter `download_depot 1498940 1498941 7126354185184625380`. Download, extract, and copy the game files to the `binkystrashservice/assets` directory.",
     "genres": [
       "platformer"
     ],
@@ -27,6 +27,11 @@
         "name": "itch.io",
         "gameurl": "https://ondydev.itch.io/binkys-trash-service",
         "developerurl": "https://ondydev.itch.io"
+      },
+      {
+        "name": "Steam",
+        "gameurl": "https://store.steampowered.com/app/1498940/Binkys_Trash_Service/",
+        "developerurl": "https://store.steampowered.com/developer/ondydev"
       }
     ],
     "availability": "paid",


### PR DESCRIPTION
As [discussed](https://discord.com/channels/1122861252088172575/1398586277049139230/1506794366298226810) in the PortMaster Discord, Binky's Trash Service can actually support the Steam version as well since v1.0.5 is identical on Steam and Itch - the newest version on Steam is v1.1.0. Until the newest version is also supported, players who only own the game on Steam can still play the port using the console's download depot command.