### PR TITLE
BAD END THEATHER download instructions

### DIFF
--- a/ports/badendtheater/port.json
+++ b/ports/badendtheater/port.json
@@ -13,8 +13,8 @@
     ],
     "desc": "Bad End Theater is a charmingly cruel little story game where everything goes wrong and that’s exactly the point.\nYou guide a cast of cute-but-doomed characters through branching paths, knowing full well that every choice leads to another terrible ending. The fun comes from experimenting: change one role, replay the story, and watch how fate twists in new, often darkly funny ways.",
     "desc_md": null,
-    "inst": "Either buy the game on Steam https://store.steampowered.com/app/1764390/BAD_END_THEATER or GOG  https://www.gog.com/de/game/bad_end_theater and copy the \"game\" folder into the ports \"badendtheater\" folder\n",
-    "inst_md": "Either buy the game on [Steam](https://store.steampowered.com/app/1764390/BAD_END_THEATER) or [GOG](https://www.gog.com/de/game/bad_end_theater)  and copy the \"game\" folder into the ports ",
+    "inst": "Either buy the game on Steam https://store.steampowered.com/app/1764390/BAD_END_THEATER or GOG  https://www.gog.com/de/game/bad_end_theater. For Steam version, open the Steam console and enter the following command to get a compatible version: download_depot 1764390 1764391 5823322159234091361, then copy the \"game\" folder into the ports \"badendtheater\" folder. From GOG installation, just copy the \"game\" folder into the ports \"badendtheater\" folder",
+    "inst_md": "Either buy the game on [Steam](https://store.steampowered.com/app/1764390/BAD_END_THEATER) or [GOG](https://www.gog.com/de/game/bad_end_theater).  For Steam version, open the [Steam console](steam://open/console) and enter the following command to get a compatible version: `download_depot 1764390 1764391 5823322159234091361`, then copy the \"game\" folder into the ports \"badendtheater\" folder. From GOG installation, just copy the \"game\" folder into the ports \"badendtheater\" folder",
     "genres": [
       "visual novel"
     ],


### PR DESCRIPTION
The current version is built with renpy 8.5 and wont work anymore, so adjusting to depot. GOG seems to be still on old release.
