### PR TITLE
Update 3 ports that require swap to accomodate dArkOS-RE

### DIFF
--- a/ports/duke3dawo/Duke3D - Alien World Order.sh
+++ b/ports/duke3dawo/Duke3D - Alien World Order.sh
@@ -44,8 +44,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 # Ensure Swap space is prepared or eduke32 may crash or fail to launch
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
-    pm_message "Preparing Swap File, please wait..."
-    if [[ $CFW_NAME == "dArkOS" ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
         [ -e /dev/zram0 ] && $ESUDO swapoff -a
         [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
         [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
@@ -63,7 +62,6 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
         $ESUDO swapon /swapfile
     fi
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-    pm_message "Preparing Swap File, please wait..."
     [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
     [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
     $ESUDO fallocate -l 384M /media/SHARE/swapfile

--- a/ports/ionfury/Ion Fury.sh
+++ b/ports/ionfury/Ion Fury.sh
@@ -39,8 +39,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 # Ensure Swap space is prepared or eduke32 may crash or fail to launch
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
-    pm_message "Preparing Swap File, please wait..."
-    if [[ $CFW_NAME == "dArkOS" ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
         [ -e /dev/zram0 ] && $ESUDO swapoff -a
         [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
         [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
@@ -58,7 +57,6 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
         $ESUDO swapon /swapfile
     fi
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-    pm_message "Preparing Swap File, please wait..."
     [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
     [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
     $ESUDO fallocate -l 384M /media/SHARE/swapfile

--- a/ports/rott/Rise of the Triad - Dark War.sh
+++ b/ports/rott/Rise of the Triad - Dark War.sh
@@ -29,8 +29,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
-    pm_message "Preparing Swap File, please wait..."
-    if [[ $CFW_NAME == "dArkOS" ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
         [ -e /dev/zram0 ] && $ESUDO swapoff -a
         [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
         [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
@@ -49,7 +48,6 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     fi
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-    pm_message "Preparing Swap File, please wait..."
     [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
     [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
     $ESUDO fallocate -l 384M /media/SHARE/swapfile

--- a/ports/rott/Rise of the Triad - The Hunt Begins.sh
+++ b/ports/rott/Rise of the Triad - The Hunt Begins.sh
@@ -29,8 +29,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 export LD_LIBRARY_PATH="$GAMEDIR/libs.${DEVICE_ARCH}:$LD_LIBRARY_PATH"
 
 if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
-    pm_message "Preparing Swap File, please wait..."
-    if [[ $CFW_NAME == "dArkOS" ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
         [ -e /dev/zram0 ] && $ESUDO swapoff -a
         [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
         [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
@@ -49,7 +48,6 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     fi
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-    pm_message "Preparing Swap File, please wait..."
     [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
     [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
     $ESUDO fallocate -l 384M /media/SHARE/swapfile


### PR DESCRIPTION
Update 3 ports that require swap to accomodate dArkOS-RE

Duke Nukem 3D - Alien World Order (uses eDuke32)
Ion Fury (also eDuke32)
Rise of the Triad (The Hunt Begins shareware and Dark War)

Tested on dArkOSRE on R36S clone.
Duke 3D AWO and Ion Fury did not launch at all and RoTT did not consistently start up prior on dArkOSRE and now they do.