### PR TITLE
Update README for Deathroad to Canada

### DIFF
--- a/ports/deathroad/README.md
+++ b/ports/deathroad/README.md
@@ -6,12 +6,20 @@ https://store.steampowered.com/app/252610/Death_Road_to_Canada/
 
 
 Installation:
-STEAM:
--Open the Steam Console and use 'download_depot 252610 252612 5968100789458006612' to download the correct version of the game. The Steam Console will tell you where the location to find these files is after the download.
-GOG:
-Using GOG, you'll need to go to your games list and find 'Manage' for this game. Turn off automatic downloads and then download the version that is from 04-02-2026 (or closest to it). Use those game files.
--Dump them straight into /ports/deathroad/ folder
--Launch the game via your console
+### STEAM:
+
+- Open the Steam Console and use `download_depot 252610 252612 5968100789458006612` to download the correct version of the game.
+- The Steam Console will tell you where the location to find these files is after the download.
+- Dump them straight into /ports/deathroad/ folder
+- Launch the game on your handheld
+
+### GOG:
+
+- Using GOG, you'll need to go to your games list and find 'Manage' for this game.
+- Turn off automatic downloads and then download the version that is from 04-02-2026 (or closest to it).
+- Use those game files.
+- Dump them straight into /ports/deathroad/ folder
+- Launch the game on your handheld
 
 Steam Game files work, but you will get a tiny popup on top, may cause incompatablity with certain mods.
 GoG Game files will work without issue.

--- a/ports/deathroad/README.md
+++ b/ports/deathroad/README.md
@@ -6,7 +6,10 @@ https://store.steampowered.com/app/252610/Death_Road_to_Canada/
 
 
 Installation:
--Take the Windows/Linux game files from your game folder
+STEAM:
+-Open the Steam Console and use 'download_depot 252610 252612 5968100789458006612'to download the correct version of the game. The Steam Console will tell you where the location to find these files is after the download.
+GOG:
+Using GOG, you'll need to go to your games list and find 'Manage' for this game. Turn off automatic downloads and then download the version that is BEFORE 05-31-2026. Use those game files.
 -Dump them straight into /ports/deathroad/ folder
 -Launch the game via your console
 

--- a/ports/deathroad/README.md
+++ b/ports/deathroad/README.md
@@ -7,7 +7,7 @@ https://store.steampowered.com/app/252610/Death_Road_to_Canada/
 
 Installation:
 STEAM:
--Open the Steam Console and use 'download_depot 252610 252612 5968100789458006612'to download the correct version of the game. The Steam Console will tell you where the location to find these files is after the download.
+-Open the Steam Console and use 'download_depot 252610 252612 5968100789458006612' to download the correct version of the game. The Steam Console will tell you where the location to find these files is after the download.
 GOG:
 Using GOG, you'll need to go to your games list and find 'Manage' for this game. Turn off automatic downloads and then download the version that is from 04-02-2026 (or closest to it). Use those game files.
 -Dump them straight into /ports/deathroad/ folder

--- a/ports/deathroad/README.md
+++ b/ports/deathroad/README.md
@@ -9,7 +9,7 @@ Installation:
 STEAM:
 -Open the Steam Console and use 'download_depot 252610 252612 5968100789458006612'to download the correct version of the game. The Steam Console will tell you where the location to find these files is after the download.
 GOG:
-Using GOG, you'll need to go to your games list and find 'Manage' for this game. Turn off automatic downloads and then download the version that is BEFORE 05-31-2026. Use those game files.
+Using GOG, you'll need to go to your games list and find 'Manage' for this game. Turn off automatic downloads and then download the version that is from 04-02-2026 (or closest to it). Use those game files.
 -Dump them straight into /ports/deathroad/ folder
 -Launch the game via your console
 


### PR DESCRIPTION
An update to the game apparently broke this port. Using the previous build which the port was built for, still works. These are just changes to the Readme for help getting those files. Slayer366 was the one who found this out by helping someone in #port-help.
