### PR TITLE
Fix typo in Kudamono Merge port.json runtime configuration

### DIFF
--- a/ports/kudamonomerge/port.json
+++ b/ports/kudamonomerge/port.json
@@ -22,7 +22,7 @@
         "rtr": false,
         "exp": false,
         "runtime": [
-            "pyxel_2.4.6._python_3.11.squashfs"
+            "pyxel_2.4.6_python_3.11.squashfs"
         ],
         "store": [
             {


### PR DESCRIPTION
This PR fixes a typo in the `runtime` configuration for the **Kudamono Merge** port.

This issue was reported on the PortMaster Discord:
https://discord.com/channels/1122861252088172575/1122882437291188345/1520264544310657117

In `ports/kudamonomerge/port.json`, the runtime string contained an extra dot:
- **Incorrect:** `pyxel_2.4.6._python_3.11.squashfs`
- **Correct:** `pyxel_2.4.6_python_3.11.squashfs`

This correction ensures that PortMaster can properly identify and download the correct Pyxel runtime for the game.

Sorry for the oversight and thank you for your time!
