### PR TITLE
Fix incorrect match on undertaleredyellow mod zip

### DIFF
--- a/ports/undertaleredyellow/undertaleredyellow/tools/patchscript
+++ b/ports/undertaleredyellow/undertaleredyellow/tools/patchscript
@@ -81,11 +81,11 @@ fi
 
 # First we need to verify the user placed everything correctly.
 prepare_assets() {
-    # Identify ut-red-yellow.zip
+    # Identify ut-red-and-yellow.zip
     echo "Looking for Undertale Red & Yellow zip file..."
     sleep 1
     for zipfile in "$DATADIR"/*.zip; do
-        if unzip -l "$zipfile" 2>/dev/null | grep -q "UNDERTALE\.exe"; then
+        if unzip -l "$zipfile" 2>/dev/null | grep -q "UTRY.*xdelta"; then
             MOD_ZIP="$zipfile"
             break
         fi
@@ -94,7 +94,7 @@ prepare_assets() {
     if [ -z "$MOD_ZIP" ]; then
         echo "Error: Could not find Undertale Red & Yellow zip file. Checking for unzipped assets."
         if [ ! -f "$DATADIR/utry/UNDERTALE.exe" ]; then
-            echo "Couldn't find unzipped assets! Please copy the ut-red-yellow-zip file to the assets folder."
+            echo "Couldn't find unzipped assets! Please copy the ut-red-and-yellow-zip file to the assets folder."
             mv "$LOGFILE" "$LOGERR"
             exit 1
         fi


### PR DESCRIPTION
Matching on UNDERTALE.exe returns a false positive if a user has copied the base game files to their system as a zip alongside the mod zip. This change searches for UTRY.*xdelta, to match a file that should only ever be in the UTRY zip, ensuring that it grabs the correct match even if there are other zips in the assets folder for some reason. 

## Game Information
- **Bug fix for**: Undertale Red and Yellow