### PR TITLE
Update swap blocks to accomodate newer Knulli releases

### DIFF
--- a/ports/duke3dawo/Duke3D - Alien World Order.sh
+++ b/ports/duke3dawo/Duke3D - Alien World Order.sh
@@ -62,12 +62,10 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
         $ESUDO swapon /swapfile
     fi
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-    [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-    [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-    $ESUDO fallocate -l 384M /media/SHARE/swapfile
-    $ESUDO chmod 600 /media/SHARE/swapfile
-    $ESUDO mkswap /media/SHARE/swapfile
-    $ESUDO swapon /media/SHARE/swapfile
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
 fi
 
 if [[ "${DEVICE_NAME^^}" == "X55" ]] || [[ "${DEVICE_NAME^^}" == "RG353P" ]] || [[ "${DEVICE_NAME^^}" == "RG40XX-H" ]] || [[ "${CFW_NAME^^}" == "RETRODECK" ]]; then

--- a/ports/ionfury/Ion Fury.sh
+++ b/ports/ionfury/Ion Fury.sh
@@ -57,12 +57,10 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
         $ESUDO swapon /swapfile
     fi
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-    [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-    [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-    $ESUDO fallocate -l 384M /media/SHARE/swapfile
-    $ESUDO chmod 600 /media/SHARE/swapfile
-    $ESUDO mkswap /media/SHARE/swapfile
-    $ESUDO swapon /media/SHARE/swapfile
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
 fi
 
 if [[ "${DEVICE_NAME^^}" == "X55" ]] || [[ "${DEVICE_NAME^^}" == "RG353P" ]] || [[ "${DEVICE_NAME^^}" == "RG40XX-H" ]]; then

--- a/ports/openjkdf2/Star Wars Jedi Knight - Dark Forces II.sh
+++ b/ports/openjkdf2/Star Wars Jedi Knight - Dark Forces II.sh
@@ -80,12 +80,10 @@ if [[ $DEVICE_RAM -lt "2" ]]; then
       $ESUDO swapon /swapfile
     fi
   elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-    [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-    [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-    $ESUDO fallocate -l 420M /media/SHARE/swapfile
-    $ESUDO chmod 600 /media/SHARE/swapfile
-    $ESUDO mkswap /media/SHARE/swapfile
-    $ESUDO swapon /media/SHARE/swapfile
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
   fi
 fi
 

--- a/ports/openjkdf2/Star Wars Jedi Knight - Mysteries of the Sith.sh
+++ b/ports/openjkdf2/Star Wars Jedi Knight - Mysteries of the Sith.sh
@@ -80,12 +80,10 @@ if [[ $DEVICE_RAM -lt "2" ]]; then
       $ESUDO swapon /swapfile
     fi
   elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-    [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-    [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-    $ESUDO fallocate -l 420M /media/SHARE/swapfile
-    $ESUDO chmod 600 /media/SHARE/swapfile
-    $ESUDO mkswap /media/SHARE/swapfile
-    $ESUDO swapon /media/SHARE/swapfile
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
   fi
 fi
 

--- a/ports/rott/Rise of the Triad - Dark War.sh
+++ b/ports/rott/Rise of the Triad - Dark War.sh
@@ -48,12 +48,10 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     fi
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-    [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-    [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-    $ESUDO fallocate -l 384M /media/SHARE/swapfile
-    $ESUDO chmod 600 /media/SHARE/swapfile
-    $ESUDO mkswap /media/SHARE/swapfile
-    $ESUDO swapon /media/SHARE/swapfile
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 fi
 

--- a/ports/rott/Rise of the Triad - The Hunt Begins.sh
+++ b/ports/rott/Rise of the Triad - The Hunt Begins.sh
@@ -48,12 +48,10 @@ if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
     fi
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-    [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-    [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-    $ESUDO fallocate -l 384M /media/SHARE/swapfile
-    $ESUDO chmod 600 /media/SHARE/swapfile
-    $ESUDO mkswap /media/SHARE/swapfile
-    $ESUDO swapon /media/SHARE/swapfile
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
     [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
 fi
 

--- a/ports/ubermoshcollection/Uber/gamedata/black.run
+++ b/ports/ubermoshcollection/Uber/gamedata/black.run
@@ -23,26 +23,31 @@ export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/../lib:$GAMEDIR/libs:$LD_LIBRARY_PAT
 export GMLOADER_DEPTH_DISABLE=1
 export GMLOADER_SAVEDIR="$GAMEDIR/gamedata/"
 
-if [[ "$DEVICE_RAM" -lt 2 ]]; then
-   if [[ "${CFW_NAME^^}" == *"ARKOS"* ]] || [[ "${CFW_NAME^^}" == *"ODROID"* ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-       [ -f /swapfile ] && $ESUDO rm -f /swapfile
-       $ESUDO fallocate -l 384M /swapfile
-       $ESUDO chmod 600 /swapfile
-       $ESUDO mkswap /swapfile
-       $ESUDO swapon /swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-       [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-       $ESUDO fallocate -l 384M /media/SHARE/swapfile
-       $ESUDO chmod 600 /media/SHARE/swapfile
-       $ESUDO mkswap /media/SHARE/swapfile
-       $ESUDO swapon /media/SHARE/swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   fi
+if [[ $DEVICE_RAM -lt "2" ]]; then
+  if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
+      [ -e /dev/zram0 ] && $ESUDO swapoff -a
+      [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+      [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+      [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+      modprobe zram
+      $ESUDO zramctl --find --size 420M
+      $ESUDO mkswap /dev/zram0
+      $ESUDO swapon /dev/zram0
+    else
+      [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+      [ -f /swapfile ] && $ESUDO rm -f /swapfile
+      $ESUDO fallocate -l 420M /swapfile
+      $ESUDO chmod 600 /swapfile
+      $ESUDO mkswap /swapfile
+      $ESUDO swapon /swapfile
+    fi
+  elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
+  fi
 fi
 
 cd "$GAMEDIR"
@@ -55,7 +60,6 @@ cd "$GAMEDIR"
 find gamedata -type f \( -iname "*.dll" -o -iname "*.exe" \) -delete
 
 $GPTOKEYB "gmloader" &
-pm_message "Loading, please wait... " > /dev/tty0
 
 $ESUDO chmod +x "$GAMEDIR/gmloader"
 pm_platform_helper "$GAMEDIR/gmloader"

--- a/ports/ubermoshcollection/Uber/gamedata/omega.run
+++ b/ports/ubermoshcollection/Uber/gamedata/omega.run
@@ -23,26 +23,31 @@ export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/../lib:$GAMEDIR/libs:$LD_LIBRARY_PAT
 export GMLOADER_DEPTH_DISABLE=1
 export GMLOADER_SAVEDIR="$GAMEDIR/gamedata/"
 
-if [[ "$DEVICE_RAM" -lt 2 ]]; then
-   if [[ "${CFW_NAME^^}" == *"ARKOS"* ]] || [[ "${CFW_NAME^^}" == *"ODROID"* ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-       [ -f /swapfile ] && $ESUDO rm -f /swapfile
-       $ESUDO fallocate -l 384M /swapfile
-       $ESUDO chmod 600 /swapfile
-       $ESUDO mkswap /swapfile
-       $ESUDO swapon /swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-       [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-       $ESUDO fallocate -l 384M /media/SHARE/swapfile
-       $ESUDO chmod 600 /media/SHARE/swapfile
-       $ESUDO mkswap /media/SHARE/swapfile
-       $ESUDO swapon /media/SHARE/swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   fi
+if [[ $DEVICE_RAM -lt "2" ]]; then
+  if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
+      [ -e /dev/zram0 ] && $ESUDO swapoff -a
+      [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+      [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+      [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+      modprobe zram
+      $ESUDO zramctl --find --size 420M
+      $ESUDO mkswap /dev/zram0
+      $ESUDO swapon /dev/zram0
+    else
+      [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+      [ -f /swapfile ] && $ESUDO rm -f /swapfile
+      $ESUDO fallocate -l 420M /swapfile
+      $ESUDO chmod 600 /swapfile
+      $ESUDO mkswap /swapfile
+      $ESUDO swapon /swapfile
+    fi
+  elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
+  fi
 fi
 
 cd "$GAMEDIR"
@@ -55,7 +60,6 @@ cd "$GAMEDIR"
 find gamedata -type f \( -iname "*.dll" -o -iname "*.exe" \) -delete
 
 $GPTOKEYB "gmloader" -c "$GAMEDIR/omega.gptk" &
-pm_message "Loading, please wait... " > /dev/tty0
 
 $ESUDO chmod +x "$GAMEDIR/gmloader"
 pm_platform_helper "$GAMEDIR/gmloader"

--- a/ports/ubermoshcollection/Uber/gamedata/santicide.run
+++ b/ports/ubermoshcollection/Uber/gamedata/santicide.run
@@ -23,26 +23,31 @@ export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/../lib:$GAMEDIR/libs:$LD_LIBRARY_PAT
 export GMLOADER_DEPTH_DISABLE=1
 export GMLOADER_SAVEDIR="$GAMEDIR/gamedata/"
 
-if [[ "$DEVICE_RAM" -lt 2 ]]; then
-   if [[ "${CFW_NAME^^}" == *"ARKOS"* ]] || [[ "${CFW_NAME^^}" == *"ODROID"* ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-       [ -f /swapfile ] && $ESUDO rm -f /swapfile
-       $ESUDO fallocate -l 384M /swapfile
-       $ESUDO chmod 600 /swapfile
-       $ESUDO mkswap /swapfile
-       $ESUDO swapon /swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-       [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-       $ESUDO fallocate -l 384M /media/SHARE/swapfile
-       $ESUDO chmod 600 /media/SHARE/swapfile
-       $ESUDO mkswap /media/SHARE/swapfile
-       $ESUDO swapon /media/SHARE/swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   fi
+if [[ $DEVICE_RAM -lt "2" ]]; then
+  if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
+      [ -e /dev/zram0 ] && $ESUDO swapoff -a
+      [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+      [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+      [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+      modprobe zram
+      $ESUDO zramctl --find --size 420M
+      $ESUDO mkswap /dev/zram0
+      $ESUDO swapon /dev/zram0
+    else
+      [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+      [ -f /swapfile ] && $ESUDO rm -f /swapfile
+      $ESUDO fallocate -l 420M /swapfile
+      $ESUDO chmod 600 /swapfile
+      $ESUDO mkswap /swapfile
+      $ESUDO swapon /swapfile
+    fi
+  elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
+  fi
 fi
 
 cd "$GAMEDIR"
@@ -55,7 +60,6 @@ cd "$GAMEDIR"
 find gamedata -type f \( -iname "*.dll" -o -iname "*.exe" \) -delete
 
 $GPTOKEYB "gmloader" &
-pm_message "Loading, please wait... " > /dev/tty0
 
 $ESUDO chmod +x "$GAMEDIR/gmloader"
 pm_platform_helper "$GAMEDIR/gmloader"

--- a/ports/ubermoshcollection/Uber/gamedata/ubermosh.run
+++ b/ports/ubermoshcollection/Uber/gamedata/ubermosh.run
@@ -23,26 +23,31 @@ export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/../lib:$GAMEDIR/libs:$LD_LIBRARY_PAT
 export GMLOADER_DEPTH_DISABLE=1
 export GMLOADER_SAVEDIR="$GAMEDIR/gamedata/"
 
-if [[ "$DEVICE_RAM" -lt 2 ]]; then
-   if [[ "${CFW_NAME^^}" == *"ARKOS"* ]] || [[ "${CFW_NAME^^}" == *"ODROID"* ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-       [ -f /swapfile ] && $ESUDO rm -f /swapfile
-       $ESUDO fallocate -l 384M /swapfile
-       $ESUDO chmod 600 /swapfile
-       $ESUDO mkswap /swapfile
-       $ESUDO swapon /swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-       [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-       $ESUDO fallocate -l 384M /media/SHARE/swapfile
-       $ESUDO chmod 600 /media/SHARE/swapfile
-       $ESUDO mkswap /media/SHARE/swapfile
-       $ESUDO swapon /media/SHARE/swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   fi
+if [[ $DEVICE_RAM -lt "2" ]]; then
+  if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
+      [ -e /dev/zram0 ] && $ESUDO swapoff -a
+      [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+      [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+      [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+      modprobe zram
+      $ESUDO zramctl --find --size 420M
+      $ESUDO mkswap /dev/zram0
+      $ESUDO swapon /dev/zram0
+    else
+      [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+      [ -f /swapfile ] && $ESUDO rm -f /swapfile
+      $ESUDO fallocate -l 420M /swapfile
+      $ESUDO chmod 600 /swapfile
+      $ESUDO mkswap /swapfile
+      $ESUDO swapon /swapfile
+    fi
+  elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
+  fi
 fi
 
 cd "$GAMEDIR"
@@ -55,7 +60,6 @@ cd "$GAMEDIR"
 find gamedata -type f \( -iname "*.dll" -o -iname "*.exe" \) -delete
 
 $GPTOKEYB "gmloader" &
-pm_message "Loading, please wait... " > /dev/tty0
 
 $ESUDO chmod +x "$GAMEDIR/gmloader"
 pm_platform_helper "$GAMEDIR/gmloader"

--- a/ports/ubermoshcollection/Uber/gamedata/vol3.run
+++ b/ports/ubermoshcollection/Uber/gamedata/vol3.run
@@ -23,26 +23,31 @@ export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/../lib:$GAMEDIR/libs:$LD_LIBRARY_PAT
 export GMLOADER_DEPTH_DISABLE=1
 export GMLOADER_SAVEDIR="$GAMEDIR/gamedata/"
 
-if [[ "$DEVICE_RAM" -lt 2 ]]; then
-   if [[ "${CFW_NAME^^}" == *"ARKOS"* ]] || [[ "${CFW_NAME^^}" == *"ODROID"* ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-       [ -f /swapfile ] && $ESUDO rm -f /swapfile
-       $ESUDO fallocate -l 384M /swapfile
-       $ESUDO chmod 600 /swapfile
-       $ESUDO mkswap /swapfile
-       $ESUDO swapon /swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-       [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-       $ESUDO fallocate -l 384M /media/SHARE/swapfile
-       $ESUDO chmod 600 /media/SHARE/swapfile
-       $ESUDO mkswap /media/SHARE/swapfile
-       $ESUDO swapon /media/SHARE/swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   fi
+if [[ $DEVICE_RAM -lt "2" ]]; then
+  if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
+      [ -e /dev/zram0 ] && $ESUDO swapoff -a
+      [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+      [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+      [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+      modprobe zram
+      $ESUDO zramctl --find --size 420M
+      $ESUDO mkswap /dev/zram0
+      $ESUDO swapon /dev/zram0
+    else
+      [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+      [ -f /swapfile ] && $ESUDO rm -f /swapfile
+      $ESUDO fallocate -l 420M /swapfile
+      $ESUDO chmod 600 /swapfile
+      $ESUDO mkswap /swapfile
+      $ESUDO swapon /swapfile
+    fi
+  elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
+  fi
 fi
 
 cd "$GAMEDIR"
@@ -55,7 +60,6 @@ cd "$GAMEDIR"
 find gamedata -type f \( -iname "*.dll" -o -iname "*.exe" \) -delete
 
 $GPTOKEYB "gmloader" &
-pm_message "Loading, please wait... " > /dev/tty0
 
 $ESUDO chmod +x "$GAMEDIR/gmloader"
 pm_platform_helper "$GAMEDIR/gmloader"

--- a/ports/ubermoshcollection/Uber/gamedata/vol5.run
+++ b/ports/ubermoshcollection/Uber/gamedata/vol5.run
@@ -23,26 +23,31 @@ export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/../lib:$GAMEDIR/libs:$LD_LIBRARY_PAT
 export GMLOADER_DEPTH_DISABLE=1
 export GMLOADER_SAVEDIR="$GAMEDIR/gamedata/"
 
-if [[ "$DEVICE_RAM" -lt 2 ]]; then
-   if [[ "${CFW_NAME^^}" == *"ARKOS"* ]] || [[ "${CFW_NAME^^}" == *"ODROID"* ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-       [ -f /swapfile ] && $ESUDO rm -f /swapfile
-       $ESUDO fallocate -l 384M /swapfile
-       $ESUDO chmod 600 /swapfile
-       $ESUDO mkswap /swapfile
-       $ESUDO swapon /swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-       [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-       $ESUDO fallocate -l 384M /media/SHARE/swapfile
-       $ESUDO chmod 600 /media/SHARE/swapfile
-       $ESUDO mkswap /media/SHARE/swapfile
-       $ESUDO swapon /media/SHARE/swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   fi
+if [[ $DEVICE_RAM -lt "2" ]]; then
+  if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
+      [ -e /dev/zram0 ] && $ESUDO swapoff -a
+      [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+      [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+      [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+      modprobe zram
+      $ESUDO zramctl --find --size 420M
+      $ESUDO mkswap /dev/zram0
+      $ESUDO swapon /dev/zram0
+    else
+      [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+      [ -f /swapfile ] && $ESUDO rm -f /swapfile
+      $ESUDO fallocate -l 420M /swapfile
+      $ESUDO chmod 600 /swapfile
+      $ESUDO mkswap /swapfile
+      $ESUDO swapon /swapfile
+    fi
+  elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
+  fi
 fi
 
 cd "$GAMEDIR"
@@ -55,7 +60,6 @@ cd "$GAMEDIR"
 find gamedata -type f \( -iname "*.dll" -o -iname "*.exe" \) -delete
 
 $GPTOKEYB "gmloader" &
-pm_message "Loading, please wait... " > /dev/tty0
 
 $ESUDO chmod +x "$GAMEDIR/gmloader"
 pm_platform_helper "$GAMEDIR/gmloader"

--- a/ports/ubermoshcollection/Uber/gamedata/vol7.run
+++ b/ports/ubermoshcollection/Uber/gamedata/vol7.run
@@ -23,26 +23,31 @@ export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/../lib:$GAMEDIR/libs:$LD_LIBRARY_PAT
 export GMLOADER_DEPTH_DISABLE=1
 export GMLOADER_SAVEDIR="$GAMEDIR/gamedata/"
 
-if [[ "$DEVICE_RAM" -lt 2 ]]; then
-   if [[ "${CFW_NAME^^}" == *"ARKOS"* ]] || [[ "${CFW_NAME^^}" == *"ODROID"* ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-       [ -f /swapfile ] && $ESUDO rm -f /swapfile
-       $ESUDO fallocate -l 384M /swapfile
-       $ESUDO chmod 600 /swapfile
-       $ESUDO mkswap /swapfile
-       $ESUDO swapon /swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-       [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-       $ESUDO fallocate -l 384M /media/SHARE/swapfile
-       $ESUDO chmod 600 /media/SHARE/swapfile
-       $ESUDO mkswap /media/SHARE/swapfile
-       $ESUDO swapon /media/SHARE/swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   fi
+if [[ $DEVICE_RAM -lt "2" ]]; then
+  if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
+      [ -e /dev/zram0 ] && $ESUDO swapoff -a
+      [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+      [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+      [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+      modprobe zram
+      $ESUDO zramctl --find --size 420M
+      $ESUDO mkswap /dev/zram0
+      $ESUDO swapon /dev/zram0
+    else
+      [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+      [ -f /swapfile ] && $ESUDO rm -f /swapfile
+      $ESUDO fallocate -l 420M /swapfile
+      $ESUDO chmod 600 /swapfile
+      $ESUDO mkswap /swapfile
+      $ESUDO swapon /swapfile
+    fi
+  elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
+  fi
 fi
 
 cd "$GAMEDIR"
@@ -55,7 +60,6 @@ cd "$GAMEDIR"
 find gamedata -type f \( -iname "*.dll" -o -iname "*.exe" \) -delete
 
 $GPTOKEYB "gmloader" -c "$GAMEDIR/vol7.gptk" &
-pm_message "Loading, please wait... " > /dev/tty0
 
 $ESUDO chmod +x "$GAMEDIR/gmloader"
 pm_platform_helper "$GAMEDIR/gmloader"

--- a/ports/ubermoshcollection/Uber/gamedata/wraith.run
+++ b/ports/ubermoshcollection/Uber/gamedata/wraith.run
@@ -23,26 +23,31 @@ export LD_LIBRARY_PATH="/usr/lib32:$GAMEDIR/../lib:$GAMEDIR/libs:$LD_LIBRARY_PAT
 export GMLOADER_DEPTH_DISABLE=1
 export GMLOADER_SAVEDIR="$GAMEDIR/gamedata/"
 
-if [[ "$DEVICE_RAM" -lt 2 ]]; then
-   if [[ "${CFW_NAME^^}" == *"ARKOS"* ]] || [[ "${CFW_NAME^^}" == *"ODROID"* ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
-       [ -f /swapfile ] && $ESUDO rm -f /swapfile
-       $ESUDO fallocate -l 384M /swapfile
-       $ESUDO chmod 600 /swapfile
-       $ESUDO mkswap /swapfile
-       $ESUDO swapon /swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
-       pm_message "Preparing Swap File, please wait..."
-       [ -f /media/SHARE/swapfile ] && $ESUDO swapoff -v /media/SHARE/swapfile
-       [ -f /media/SHARE/swapfile ] && $ESUDO rm -f /media/SHARE/swapfile
-       $ESUDO fallocate -l 384M /media/SHARE/swapfile
-       $ESUDO chmod 600 /media/SHARE/swapfile
-       $ESUDO mkswap /media/SHARE/swapfile
-       $ESUDO swapon /media/SHARE/swapfile
-       [ -f $GAMEDIR/timidity.cfg ] && $ESUDO rm -f $GAMEDIR/timidity.cfg
-   fi
+if [[ $DEVICE_RAM -lt "2" ]]; then
+  if [[ $CFW_NAME == *"ArkOS"* ]] || [[ $CFW_NAME == *"ODROID"* ]]; then
+    if [[ $CFW_NAME == *"dArkOS"* ]]; then
+      [ -e /dev/zram0 ] && $ESUDO swapoff -a
+      [ -e /dev/zram0 ] && $ESUDO zramctl --reset /dev/zram0
+      [ -e /dev/zram1 ] && $ESUDO zramctl --reset /dev/zram1
+      [ -e /dev/zram2 ] && $ESUDO zramctl --reset /dev/zram2
+      modprobe zram
+      $ESUDO zramctl --find --size 420M
+      $ESUDO mkswap /dev/zram0
+      $ESUDO swapon /dev/zram0
+    else
+      [ -f /swapfile ] && $ESUDO swapoff -v /swapfile
+      [ -f /swapfile ] && $ESUDO rm -f /swapfile
+      $ESUDO fallocate -l 420M /swapfile
+      $ESUDO chmod 600 /swapfile
+      $ESUDO mkswap /swapfile
+      $ESUDO swapon /swapfile
+    fi
+  elif [[ "${CFW_NAME^^}" == "KNULLI" ]]; then
+    if [ ! -e /dev/zram0 ]; then
+        pm_message "For Knulli, you must enable ZRAM.  Start -> System Settings -> Services -> ZRAMSWAP"
+        sleep 7
+    fi
+  fi
 fi
 
 cd "$GAMEDIR"
@@ -55,7 +60,6 @@ cd "$GAMEDIR"
 find gamedata -type f \( -iname "*.dll" -o -iname "*.exe" \) -delete
 
 $GPTOKEYB "gmloader" &
-pm_message "Loading, please wait... " > /dev/tty0
 
 $ESUDO chmod +x "$GAMEDIR/gmloader"
 pm_platform_helper "$GAMEDIR/gmloader"


### PR DESCRIPTION
Update swap blocks to accomodate newer Knulli releases.

The original swap creation for Knulli worked well when Solid_one and myself set it up and tested it back when Knulli Firefly was current. However, it would seem that newer releases of Knulli no longer work with this and have removed the ability to create a swapfile entirely.

This will now simply check if ZRAM is enabled and send a message to the user to enable it in Knulli's settings and as of now will no longer automatically create a swap of any kind on Knulli. It will now be recommended for Knulli users to enable it themselves with Knulli's built-in system toggle.

Affected titles:
Duke Nukem 3D: Alien World Order
Ion Fury
Star Wars Jedi Knight: Dark Forces II
Rise of the Triad
Ubermosh Collection