### PR TITLE
Minor Fix: Project: Starfighter's launch script 

### DIFF
--- a/ports/starfighter/Project Starfighter.sh
+++ b/ports/starfighter/Project Starfighter.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
 


### PR DESCRIPTION
## Game Information
- **Port**: [*Project: Starfighter*](https://github.com/PortsMaster/PortMaster-New/tree/main/ports/starfighter)
## Submission Requirements
### CFW Tests
Ensure your game has been tested on all major CFWs:
- [x] dArkOS
  - `trixie-06072026` A10 Mini
### File Structure
- [ ] `python3 tools/build_release.py`
    ```
    Bad port starfighter
    - Warnings:
      Script starfighter/share/starfighter/locale/genpot.sh found in port directories, this can cause issues.
    
    Changes:
      New:       1
      Broken:    0
      Updated:   0
      Unchanged: 0
    
    Total Ports: 1
    ```

While testing the upcoming port of the *Crop and Claw 2* demo, I noticed that that port would not run on dArkOS due to the fact that the launch script used `#!/bin/sh` rather than `#!/bin/bash`. On dArkOS, `sh` is provided by `dash`, which doesn't seem to like our launch scripts.

I searched the repo, and I noticed that this port also had this issue.

I didn't come up with any other launch scripts that **did not** use `#!/bin/bash`, and I think all example launch scripts (e.g. [one](https://portmaster.games/packaging.html#the-launchscript-sh), [two](https://jantrueno.github.io/PortMaster-Wiki/contribute/porting/script-templates/), [three](https://github.com/binarycounter/Westonpack/wiki/Godot-4-Example#example-script)) use it as well. For this reason, I don't think this change needs to be widely tested, although I can confirm that this port did not work on my dArkOS device before making the change.

`python3 tools/build_release.py` has a warning, but this does not seem to be related to this change.

There were some other ports I found that used `#!/bin/sh` in various scripts, but they were not using it in *launch scripts*. I haven't checked to see whether any of them would have a problem or not.