### PR TITLE
dARKOS Flashing Screen Fix

### DIFF
--- a/ports/maxpayne/Max Payne.sh
+++ b/ports/maxpayne/Max Payne.sh
@@ -42,7 +42,6 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 source $controlfolder/runtimes/"love_11.5"/love.txt
 
-echo "Starting Launcher"
 
 # Remove debug log
 rm -f "debug.log"

--- a/ports/maxpayne/Max Payne.sh
+++ b/ports/maxpayne/Max Payne.sh
@@ -42,7 +42,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 source $controlfolder/runtimes/"love_11.5"/love.txt
 
-pm_message "Starting Launcher"
+#pm_message "Starting Launcher"
 
 # Remove debug log
 rm -f "debug.log"

--- a/ports/maxpayne/Max Payne.sh
+++ b/ports/maxpayne/Max Payne.sh
@@ -42,7 +42,7 @@ export SDL_GAMECONTROLLERCONFIG="$sdl_controllerconfig"
 
 source $controlfolder/runtimes/"love_11.5"/love.txt
 
-#pm_message "Starting Launcher"
+echo "Starting Launcher"
 
 # Remove debug log
 rm -f "debug.log"


### PR DESCRIPTION
pm_message causes dARKOS screen to flash between the launcher and the portmaster message window.  Removing the "Starting Launcher" fixes the issue completely.