### PR TITLE
Fix: Apply pyxel.reset() workaround to Dungeon Antiqua 2

### DIFF
--- a/ports/dungeonantiqua2/Dungeon Antiqua 2.sh
+++ b/ports/dungeonantiqua2/Dungeon Antiqua 2.sh
@@ -80,7 +80,26 @@ export PYTHONPATH="${GAMEDIR}/gamedata/${DEVICE_ARCH}:${PYTHONPATH:-}"
 
 export DEVICE_NAME
 export CFW_NAME
-"${pyxel_dir}/bin/pyxel" play "${GAMEDIR}/gamedata/${PYXEL_PKG}"
+
+# pyxel.reset() workaround (Pyxel 2.5.0+)
+#    pyxel.reset() spawns a background process and then terminates the parent
+#    process. Therefore, the spawned process is left running. As a result, it
+#    is highly likely to affect applications launched by the user.
+#    Setting PYXEL_WATCH_STATE_FILE=/dev/null prevents this and returns
+#    exit code 82, allowing this loop to safely restart the game.
+# https://github.com/kitao/pyxel/blob/v2.9.5/crates/pyxel-binding/src/system_wrapper.rs#L66-L67
+export PYXEL_WATCH_STATE_FILE=/dev/null
+
+while true; do
+    "${pyxel_dir}/bin/pyxel" play "${GAMEDIR}/gamedata/${PYXEL_PKG}"
+    EXIT_CODE=$?
+    
+    # 0x52 (82) is returned when pyxel.reset() is called by the game (e.g. changing resolution)
+    if [ $EXIT_CODE -ne 82 ]; then
+        break
+    fi
+    echo "pyxel.reset() detected. Restarting game cleanly..."
+done
 
 if [[ "$PM_CAN_MOUNT" != "N" ]]; then
     $ESUDO umount "${pyxel_dir}"


### PR DESCRIPTION
## Game Information

* **Update / Fix for**: Dungeon Antiqua 2

### Summary

This PR applies a workaround for the `pyxel.reset()` behavior in Dungeon Antiqua 2.

### Description

In Dungeon Antiqua 2, changing the screen size and returning to the title screen triggers `pyxel.reset()`.

On some CFWs, this can make the game appear to have closed and cause the CFW interface to become accessible again, even though the game process is still running.

On ROCKNIX, for example, another game can then be launched while Dungeon Antiqua 2 is still running, resulting in multiple games running simultaneously, as shown in the attached photo.

<img width="887" height="392" alt="MultipleInstances_da2" src="https://github.com/user-attachments/assets/df00c81f-6e5f-4885-ad0c-6d76ce87bdfa" />

Discord post: https://discord.com/channels/1122861252088172575/1509108648654405692/1533049980720513076

### Fix

To avoid this issue, I updated the launch script with the following workaround:

* Set `PYXEL_WATCH_STATE_FILE=/dev/null` so that `pyxel.reset()` exits with code `82` instead of spawning a new process.
* Added a `while true` loop to detect exit code `82` and restart the game cleanly.

Pyxel source:
https://github.com/kitao/pyxel/blob/v2.9.5/crates/pyxel-binding/src/system_wrapper.rs#L66-L67

## Authorship & Testing

* [x] I wrote and understand this script/patch myself, or clearly marked which parts came from an AI assistant and reviewed them
* [x] I can explain every non-standard line in my launch script

## Submission Requirements

### CFW Tests

* [x] ArkOS
* [x] AmberELEC
* [x] ROCKNIX
* [x] muOS
* [x] Knulli
* [ ] Crossmix (Optional)
* [x] Other (RetroDECK Linux Desktop)

### Resolution Tests

* [ ] 480x320 (Optional)
* [x] 640x480
* [x] 720x720 (RGB30) (Optional)
* [x] Higher resolutions (e.g., 1280x720)
