### PR TITLE
Tamashii: accept the itch.io executable name

### DIFF
--- a/ports/tamashii/Tamashii.sh
+++ b/ports/tamashii/Tamashii.sh
@@ -27,12 +27,15 @@ export GMLOADER_PLATFORM="os_linux"
 cd "$GAMEDIR"
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
-if [ -f "./gamedata/game.exe" ]; then
+# Steam ships "game.exe", itch.io ships "tamashii.exe"
+gameexe=$(ls ./gamedata/*.exe 2>/dev/null | head -n1)
+
+if [ -f "$gameexe" ]; then
     # Extract its contents in place using 7zzs
-    ./libs/7zzs x "./gamedata/game.exe" -o"./gamedata/"
+    ./libs/7zzs x "$gameexe" -o"./gamedata/"
 fi
 
- files_to_remove=("./gamedata/game.exe"
+ files_to_remove=("$gameexe"
 "./gamedata/D3DX9_43.dll"
 "./gamedata/options.ini")
  


### PR DESCRIPTION
### Problem

`Tamashii.sh` tests for one exact filename:

```sh
if [ -f "./gamedata/game.exe" ]; then
    ./libs/7zzs x "./gamedata/game.exe" -o"./gamedata/"
fi
```

`game.exe` is the Steam build's name. The itch.io release ships `tamashii.exe`. With the itch.io copy the test never matches, `7zzs` never runs, no `data.win` appears, and the later `mv gamedata/data.win gamedata/game.droid` is skipped. The script then launches `gmloader` with no data file:

```
Trying to load WAD from /userdata/roms/ports/tamashii/gamedata/game.droid.
platform/common/zip_util.c:71: Failed to stat file 'assets/game.droid'.
ports/gmloader/libyoyo.c:496: Unable to open game's WAD file.
```

The port's own `port.json` links the itch.io store page, so the itch.io build is an expected source.

### Fix

Pick the first `*.exe` in `gamedata` instead of hardcoding the name. Steam and itch.io copies both work, and the removal list drops the same file that was extracted.

### Notes

- `ls ... 2>/dev/null` matches the style already used a few lines below for the `.ogg` check.
- No `.exe` present: `gameexe` is empty, `[ -f "" ]` is false, `rm -f ""` is a no-op. Same behaviour as before.
- Both `game.exe` and `tamashii.exe` present: `game.exe` wins, as before.
- LF endings, mode 644 unchanged, `bash -n` clean.

### Testing

Reported and reproduced on RG35XX-H (H700) at 640x480 with the itch.io build; the log above is from that device. I could not run the full distribution matrix. The change touches only filename selection, not rendering, input or libraries, so behaviour on other CFWs should be unchanged — the Steam path is byte-identical in effect. Happy to hold for someone with wider hardware access to confirm.
