### PR TITLE
Fix TMNT: Shredder's Revenge startup with macOS game data

### DIFF
--- a/ports/tmntsr/TMNTShreddersRevenge.sh
+++ b/ports/tmntsr/TMNTShreddersRevenge.sh
@@ -21,6 +21,7 @@ get_controls
 export ESUDO=$ESUDO
 export gameassembly="TMNT.exe"
 export gamedir="/$directory/ports/tmntsr"
+find "$gamedir/gamedata" -type f -name '.DS_Store' -exec rm -f {} \;
 cd "$gamedir/gamedata"
 
 # Grab text output...


### PR DESCRIPTION
## Game Information
- **Update Port for**: TMNT: Shredder's Revenge
- **URL**: https://store.steampowered.com/app/1361510/Teenage_Mutant_Ninja_Turtles_Shredders_Revenge/

Game data copied from macOS can contain `.DS_Store` files. TMNT's FNA content loader treats these files as assets and attempts to load `Content/AssetPacks/.xnb`, causing startup to fail.

This removes `.DS_Store` files from `gamedata` before launch, similar to what the [Celeste launch script does](https://github.com/PortsMaster/PortMaster-New/blob/8d3a5db24bb0e8944b71242c6a00c56a08702fe4/ports/celeste/Celeste.sh#L54) for `._*` metadata.

### Testing
- [x] Tested on ROCKNIX. removing `.DS_Store` cleared `ContentLoadException: Could not load asset AssetPacks/!` and reached the splash screens.
- [x] `bash -n ports/tmntsr/TMNTShreddersRevenge.sh`

## Authorship & Testing

- [x] I wrote and understand this script/patch myself, or clearly marked which parts came from an AI assistant and reviewed them
- [x] I can explain every non-standard line in my launch script
